### PR TITLE
Add complete spanish translation, various corrections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,13 +37,14 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/translations.qrc ${CMAKE_CURRENT_BINA
 set(RESOURCES resources.qrc ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc)
 
 file (GLOB TS_FILES
-  ts/omm_en.ts
   ts/omm_de.ts
+  ts/omm_en.ts
+  ts/omm_es.ts
 )
 
 qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
 
-foreach (lang en de)
+foreach (lang de en es)
   foreach (pref qt qtbase qt_help qtlocation)
     file(COPY ${QT_QM_PATH}/${pref}_${lang}.qm DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
   endforeach(pref)
@@ -75,4 +76,3 @@ target_link_libraries(ommpfritt libommpfritt)
 
 install(TARGETS ommpfritt RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib/static)
 install(TARGETS libommpfritt RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib/static)
-

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ There is a [screencast on youtube](https://www.youtube.com/watch?v=6X5Lo7kq5eM) 
 - properties can be added at runtime
 - **multi-selection** support for properties: compatible intersection of properties of all selected items (objects, tags, styles, tools) is shown and can be modified simultaneously
 - **flexible, customizable key binding sequences** (aka short-cuts)
-- **multi-language** (currently English and German only)
+- **multi-language** (currently English, Spanish and German only)
 - **rasterize** to `png` and `jpg`
 - **export** to SVG
 
@@ -102,4 +102,3 @@ Currently we're looking for
 ## Building
 
 see [build.md](build.md)
-

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -386,7 +386,7 @@ bool Scene::can_remove( QWidget* parent, std::set<AbstractPropertyOwner*> select
   const auto reference_holder_map = find_reference_holders(selection);
   if (reference_holder_map.size() > 0) {
     const auto message = QObject::tr("There are %1 items being referenced by other items.\n"
-                                     "Remove the refrenced items anyway?")
+                                     "Remove the referenced items anyway?")
                                     .arg(reference_holder_map.size());
     const auto decision = QMessageBox::warning( parent, QObject::tr("Warning"), message,
                                                 QMessageBox::YesToAll | QMessageBox::Cancel );

--- a/translations.qrc
+++ b/translations.qrc
@@ -3,13 +3,18 @@
     <qresource prefix="/qm">
         <file>qt_de.qm</file>
         <file>qt_en.qm</file>
+        <file>qt_es.qm</file>
         <file>qt_help_de.qm</file>
         <file>qt_help_en.qm</file>
+        <file>qt_help_es.qm</file>
         <file>qtbase_de.qm</file>
         <file>qtbase_en.qm</file>
+        <file>qtbase_es.qm</file>
         <file>qtlocation_de.qm</file>
         <file>qtlocation_en.qm</file>
+        <file>qtlocation_es.qm</file>
         <file>omm_de.qm</file>
         <file>omm_en.qm</file>
+        <file>omm_es.qm</file>
     </qresource>
 </RCC>

--- a/ts/omm_de.ts
+++ b/ts/omm_de.ts
@@ -798,7 +798,7 @@ Soll die Selektion trotzdem entfernt werden?</translation>
     </message>
     <message>
         <source>seed</source>
-        <translation>Seed key</translation>
+        <translation>Seed</translation>
     </message>
     <message>
         <source>length</source>

--- a/ts/omm_de.ts
+++ b/ts/omm_de.ts
@@ -368,9 +368,9 @@
     </message>
     <message>
         <source>There are %1 items being referenced by other items.
-Remove the refrenced items anyway?</source>
         <translation>%1 Elemente sind von der Selektion abhänging.
-Soll die Selektion troztdem entfernt werden?</translation>
+Remove the referenced items anyway?</source>
+Soll die Selektion trotzdem entfernt werden?</translation>
     </message>
     <message>
         <source>Warning</source>
@@ -782,7 +782,7 @@ Soll die Selektion troztdem entfernt werden?</translation>
     </message>
     <message>
         <source>V-Align</source>
-        <translation>Vert. Ausrichting</translation>
+        <translation>Vert. Ausrichtung</translation>
     </message>
     <message>
         <source>Tab width</source>

--- a/ts/omm_de.ts
+++ b/ts/omm_de.ts
@@ -368,8 +368,8 @@
     </message>
     <message>
         <source>There are %1 items being referenced by other items.
-        <translation>%1 Elemente sind von der Selektion abhänging.
 Remove the referenced items anyway?</source>
+        <translation>%1 Elemente in der Selektion werden von anderen Objekten referenziert.
 Soll die Selektion trotzdem entfernt werden?</translation>
     </message>
     <message>

--- a/ts/omm_en.ts
+++ b/ts/omm_en.ts
@@ -368,7 +368,7 @@
     </message>
     <message>
         <source>There are %1 items being referenced by other items.
-Remove the refrenced items anyway?</source>
+Remove the referenced items anyway?</source>
         <translation>There are %1 items being referenced by the selection.
 Remove the selected items anyway?</translation>
     </message>

--- a/ts/omm_es.ts
+++ b/ts/omm_es.ts
@@ -1,0 +1,1538 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
+<context>
+    <name>BoolProperty</name>
+    <message>
+        <source>BoolProperty</source>
+        <translation>Atributo Booleano</translation>
+    </message>
+</context>
+<context>
+    <name>ColorProperty</name>
+    <message>
+        <source>ColorProperty</source>
+        <translation>Atributo Color</translation>
+    </message>
+</context>
+<context>
+    <name>ExportDialog</name>
+    <message>
+        <source>Raster</source>
+        <translation>Raster</translation>
+    </message>
+    <message>
+        <source>SVG</source>
+        <translation>SVG</translation>
+    </message>
+    <message>
+        <source>x</source>
+        <translation>x</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <source>Resolution:</source>
+        <translation>Resolución:</translation>
+    </message>
+    <message>
+        <source>Scaling:</source>
+        <translation>Escala:</translation>
+    </message>
+</context>
+<context>
+    <name>FloatProperty</name>
+    <message>
+        <source>FloatProperty</source>
+        <translation>Atributo Numérico de Punto Flotante</translation>
+    </message>
+</context>
+<context>
+    <name>FloatVectorProperty</name>
+    <message>
+        <source>FloatVectorProperty</source>
+        <translation>Atributo Vector de Punto Flotante</translation>
+    </message>
+</context>
+<context>
+    <name>IntegerProperty</name>
+    <message>
+        <source>IntegerProperty</source>
+        <translation>Atributo Número Entero</translation>
+    </message>
+</context>
+<context>
+    <name>IntegerVectorProperty</name>
+    <message>
+        <source>IntegerVectorProperty</source>
+        <translation>Atributo Vector de Número Entero</translation>
+    </message>
+</context>
+<context>
+    <name>ObjectTransformation</name>
+    <message>
+        <source>ObjectTransformation</source>
+        <translation>Transformación de Objeto</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsProperty</name>
+    <message>
+        <source>OptionsProperty</source>
+        <translation>Atributo Opción</translation>
+    </message>
+</context>
+<context>
+    <name>Point</name>
+    <message>
+        <source>Point</source>
+        <translation>Punto</translation>
+    </message>
+</context>
+<context>
+    <name>Property</name>
+    <message>
+        <source>user properties</source>
+        <translation>Atributo</translation>
+    </message>
+</context>
+<context>
+    <name>PropertyItem</name>
+    <message>
+        <source>&lt;unnamed property&gt;</source>
+        <translation>Elemento Atributo</translation>
+    </message>
+</context>
+<context>
+    <name>PropertyOwner</name>
+    <message>
+        <source>AbstractPropertyOwner</source>
+        <translation>Dueño de Atributo</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>add</source>
+        <translation>Añadir</translation>
+    </message>
+    <message>
+        <source>copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <source>ModifyPointsCommand</source>
+        <translation>Modificar puntos</translation>
+    </message>
+    <message>
+        <source>AddPointsCommand</source>
+        <translation>Añadir puntos</translation>
+    </message>
+    <message>
+        <source>RemovePointsCommand</source>
+        <translation>Borrar puntos</translation>
+    </message>
+    <message>
+        <source>reparent</source>
+        <translation>Elegir objeto superior</translation>
+    </message>
+    <message>
+        <source>Move tags</source>
+        <translation>Mover tags</translation>
+    </message>
+    <message>
+        <source>PointsTransformationCommand</source>
+        <translation>Transformar puntos</translation>
+    </message>
+    <message>
+        <source>Set </source>
+        <translation>Asignar atributo </translation>
+    </message>
+    <message>
+        <source>remove</source>
+        <translation>Borrar elemento</translation>
+    </message>
+    <message>
+        <source>Modify user properties</source>
+        <translation>Modificar atributos de usuario</translation>
+    </message>
+    <message>
+        <source>omm</source>
+        <translation>omm</translation>
+    </message>
+    <message>
+        <source>ommpfritt</source>
+        <translation>omm</translation>
+    </message>
+    <message>
+        <source>modify tangents</source>
+        <translation>Modificar tangentes</translation>
+    </message>
+    <message>
+        <source>convert</source>
+        <translation>Convertir</translation>
+    </message>
+    <message>
+        <source>Linear</source>
+        <translation>Lineal</translation>
+    </message>
+    <message>
+        <source>Grid</source>
+        <translation>Rejilla</translation>
+    </message>
+    <message>
+        <source>Radial</source>
+        <translation>Radial</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Trayecto</translation>
+    </message>
+    <message>
+        <source>Script</source>
+        <translation>Script</translation>
+    </message>
+    <message>
+        <source>mode</source>
+        <translation>Modo</translation>
+    </message>
+    <message>
+        <source>Cloner</source>
+        <translation>Clonador</translation>
+    </message>
+    <message>
+        <source>count</source>
+        <translation>Número</translation>
+    </message>
+    <message>
+        <source>distance</source>
+        <translation>Distancia</translation>
+    </message>
+    <message>
+        <source>radius</source>
+        <translation>Radio</translation>
+    </message>
+    <message>
+        <source>path</source>
+        <translation>Trayecto</translation>
+    </message>
+    <message>
+        <source>start</source>
+        <translation>Inicio</translation>
+    </message>
+    <message>
+        <source>end</source>
+        <translation>Fin</translation>
+    </message>
+    <message>
+        <source>align</source>
+        <translation>Alinear</translation>
+    </message>
+    <message>
+        <source>Clamp</source>
+        <translation>Restringir</translation>
+    </message>
+    <message>
+        <source>Wrap</source>
+        <translation>Repetir</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation>Ocultar</translation>
+    </message>
+    <message>
+        <source>Reflect</source>
+        <translation>Reflejar</translation>
+    </message>
+    <message>
+        <source>border</source>
+        <translation>Borde</translation>
+    </message>
+    <message>
+        <source>code</source>
+        <translation>Código</translation>
+    </message>
+    <message>
+        <source>r</source>
+        <translation>Radio</translation>
+    </message>
+    <message>
+        <source>ellipse</source>
+        <translation>Elipse</translation>
+    </message>
+    <message>
+        <source>n</source>
+        <translation>Puntos</translation>
+    </message>
+    <message>
+        <source>filename</source>
+        <translation>Nombre de fichero</translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation>Opacidad</translation>
+    </message>
+    <message>
+        <source>image</source>
+        <translation>Imagen</translation>
+    </message>
+    <message>
+        <source>visible</source>
+        <translation>Visible</translation>
+    </message>
+    <message>
+        <source>hidden</source>
+        <translation>Ocultado</translation>
+    </message>
+    <message>
+        <source>hide tree</source>
+        <translation>Ocultar jerarquía</translation>
+    </message>
+    <message>
+        <source>basic</source>
+        <translation>Básico</translation>
+    </message>
+    <message>
+        <source>active</source>
+        <translation>Activo</translation>
+    </message>
+    <message>
+        <source>&lt;unnamed object&gt;</source>
+        <translation>Objeto sin nombre</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <source>pos</source>
+        <translation>Posición</translation>
+    </message>
+    <message>
+        <source>scale</source>
+        <translation>Escala</translation>
+    </message>
+    <message>
+        <source>rotation</source>
+        <translation>Rotación</translation>
+    </message>
+    <message>
+        <source>shear</source>
+        <translation>Inclinación</translation>
+    </message>
+    <message>
+        <source>Failed to retrieve object type &apos;%1&apos;.</source>
+        <translation>El tipo de objeto &apos;%1&apos; no se pudo obtener.</translation>
+    </message>
+    <message>
+        <source>closed</source>
+        <translation>Cerrado</translation>
+    </message>
+    <message>
+        <source>linear</source>
+        <translation>Lineal</translation>
+    </message>
+    <message>
+        <source>smooth</source>
+        <translation>Cúbico</translation>
+    </message>
+    <message>
+        <source>bezier</source>
+        <translation>Bézier</translation>
+    </message>
+    <message>
+        <source>interpolation</source>
+        <translation>Interpolación</translation>
+    </message>
+    <message>
+        <source>ProceduralPath</source>
+        <translation>Trayecto Procedural</translation>
+    </message>
+    <message>
+        <source>pen</source>
+        <translation>Lápiz</translation>
+    </message>
+    <message>
+        <source>color</source>
+        <translation>Color</translation>
+    </message>
+    <message>
+        <source>width</source>
+        <translation>Ancho</translation>
+    </message>
+    <message>
+        <source>brush</source>
+        <translation>Pincel</translation>
+    </message>
+    <message>
+        <source>There are %1 items being referenced by other items.
+Remove the referenced items anyway?</source>
+        <translation>Otros elementos tienen referencias a %1 elementos en la selección.
+Borrar la selección de todos modos?</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>Advertencia</translation>
+    </message>
+    <message>
+        <source>Remove Selection</source>
+        <translation>Borrar selección</translation>
+    </message>
+    <message>
+        <source>position</source>
+        <translation>Posición</translation>
+    </message>
+    <message>
+        <source>script</source>
+        <translation>Script</translation>
+    </message>
+    <message>
+        <source>per frame</source>
+        <translation>Por fotograma</translation>
+    </message>
+    <message>
+        <source>on request</source>
+        <translation>Por Demanda</translation>
+    </message>
+    <message>
+        <source>update</source>
+        <translation>Actualización</translation>
+    </message>
+    <message>
+        <source>evaluate</source>
+        <translation>Evaluar</translation>
+    </message>
+    <message>
+        <source>style</source>
+        <translation>Estilo</translation>
+    </message>
+    <message>
+        <source>tool</source>
+        <translation>Herramienta</translation>
+    </message>
+    <message>
+        <source>global</source>
+        <translation>Global</translation>
+    </message>
+    <message>
+        <source>local</source>
+        <translation>Local</translation>
+    </message>
+    <message>
+        <source>Alignment</source>
+        <translation>Alineamiento</translation>
+    </message>
+    <message>
+        <source>Object</source>
+        <translation>Objeto</translation>
+    </message>
+    <message>
+        <source>Axis</source>
+        <translation>Eje</translation>
+    </message>
+    <message>
+        <source>Mode</source>
+        <translation>Modo</translation>
+    </message>
+    <message>
+        <source>Horizontal</source>
+        <translation>Horizontal</translation>
+    </message>
+    <message>
+        <source>Vertical</source>
+        <translation>Vertical</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>Dirección</translation>
+    </message>
+    <message>
+        <source>Mirror</source>
+        <translation>Simetrizar</translation>
+    </message>
+    <message>
+        <source>Individual</source>
+        <translation>Individual</translation>
+    </message>
+    <message>
+        <source>tangent</source>
+        <translation>Tangente</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <comment>keybindings</comment>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <source>context</source>
+        <comment>keybindings</comment>
+        <translation>Contexto</translation>
+    </message>
+    <message>
+        <source>sequence</source>
+        <comment>keybindings</comment>
+        <translation>Secuencia</translation>
+    </message>
+    <message>
+        <source>&lt; invalid &gt;</source>
+        <comment>property</comment>
+        <translation>Inválido</translation>
+    </message>
+    <message>
+        <source>property manager</source>
+        <comment>PropertyManager</comment>
+        <translation>Controles de Atributos</translation>
+    </message>
+    <message>
+        <source>user properties</source>
+        <comment>PropertyManager</comment>
+        <translation>Controles de Atributos Usuarios</translation>
+    </message>
+    <message>
+        <source>edit ...</source>
+        <comment>PropertyManager</comment>
+        <translation>Editar ...</translation>
+    </message>
+    <message>
+        <source>run</source>
+        <comment>PythonConsole</comment>
+        <translation>Ejecutar</translation>
+    </message>
+    <message>
+        <source>clear</source>
+        <comment>PythonConsole</comment>
+        <translation>Borrar</translation>
+    </message>
+    <message>
+        <source>no output yet.</source>
+        <comment>PythonConsole</comment>
+        <translation>Todavía nada de mostrar.</translation>
+    </message>
+    <message>
+        <source>enter command ...</source>
+        <comment>PythonConsole</comment>
+        <translation>Etra un comando ...</translation>
+    </message>
+    <message>
+        <source>&gt;&gt;&gt; </source>
+        <comment>PythonConsole</comment>
+        <translation>&gt;&gt;&gt; </translation>
+    </message>
+    <message>
+        <source>Instance</source>
+        <translation>Instancia</translation>
+    </message>
+    <message>
+        <source>reference</source>
+        <comment>Instance</comment>
+        <translation>Referencia</translation>
+    </message>
+    <message>
+        <source>combine styles</source>
+        <comment>Instance</comment>
+        <translation>Combinar estilos</translation>
+    </message>
+    <message>
+        <source>min</source>
+        <comment>NumericProperty</comment>
+        <translation>Min</translation>
+    </message>
+    <message>
+        <source>max</source>
+        <comment>NumericProperty</comment>
+        <translation>Max</translation>
+    </message>
+    <message>
+        <source>step</source>
+        <comment>NumericProperty</comment>
+        <translation>Paso</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <comment>OptionsPropertyConfigWidget</comment>
+        <translation>Advertencia</translation>
+    </message>
+    <message>
+        <source>Cannot remove last option.</source>
+        <comment>OptionsPropertyConfigWidget</comment>
+        <translation>La última opción no se puede borrar.</translation>
+    </message>
+    <message>
+        <source>single line</source>
+        <comment>StringPropertyConfigWidget</comment>
+        <translation>Línea singular</translation>
+    </message>
+    <message>
+        <source>multi line</source>
+        <comment>StringPropertyConfigWidget</comment>
+        <translation>Líneas múltiples</translation>
+    </message>
+    <message>
+        <source>file path</source>
+        <comment>StringPropertyConfigWidget</comment>
+        <translation>Ruta del archivo</translation>
+    </message>
+    <message>
+        <source>code</source>
+        <comment>StringPropertyConfigWidget</comment>
+        <translation>Código</translation>
+    </message>
+    <message>
+        <source>font</source>
+        <comment>StringPropertyConfigWidget</comment>
+        <translation>Fuente</translation>
+    </message>
+    <message>
+        <source>&lt; none &gt;</source>
+        <comment>ReferenceLineEdit</comment>
+        <translation>&lt; Ninguno &gt;</translation>
+    </message>
+    <message>
+        <source>&lt;multiple values&gt;</source>
+        <comment>ReferenceLineEdit</comment>
+        <translation>Múltiples Valores</translation>
+    </message>
+    <message>
+        <source>copy tags</source>
+        <comment>ObjectTreeAdapter</comment>
+        <translation>Copiar tags</translation>
+    </message>
+    <message>
+        <source>set styles tags</source>
+        <comment>ObjectTreeAdapter</comment>
+        <translation>Elegir tags de estilo</translation>
+    </message>
+    <message>
+        <source>object</source>
+        <comment>ObjectTreeAdapter</comment>
+        <translation>Objeto</translation>
+    </message>
+    <message>
+        <source>is visible</source>
+        <comment>ObjectTreeAdapter</comment>
+        <translation>Visibilidad</translation>
+    </message>
+    <message>
+        <source>tags</source>
+        <comment>ObjectTreeAdapter</comment>
+        <translation>Tags</translation>
+    </message>
+    <message>
+        <source>&lt; multiple values &gt;</source>
+        <comment>TextEditAdapter</comment>
+        <translation>Múltiples Valores</translation>
+    </message>
+    <message>
+        <source>size</source>
+        <translation>Tamaño</translation>
+    </message>
+    <message>
+        <source>view</source>
+        <translation>Punto de Vista</translation>
+    </message>
+    <message>
+        <source>to viewport</source>
+        <translation>Ajustar la Vista al Punto de Vista</translation>
+    </message>
+    <message>
+        <source>from viewport</source>
+        <translation>Ajustar el Punto de Vista a la Vista</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation>Fuente</translation>
+    </message>
+    <message>
+        <source>Strikeout</source>
+        <translation>Tachado</translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation>Subrayado</translation>
+    </message>
+    <message>
+        <source>Weight</source>
+        <translation>Peso</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation>Cursiva</translation>
+    </message>
+    <message>
+        <source>Overline</source>
+        <translation>Superlineado</translation>
+    </message>
+    <message>
+        <source>Mixed</source>
+        <translation>Mezclado</translation>
+    </message>
+    <message>
+        <source>All upper</source>
+        <translation>Toda mayúscula</translation>
+    </message>
+    <message>
+        <source>All lower</source>
+        <translation>Toda minúscula</translation>
+    </message>
+    <message>
+        <source>Small caps</source>
+        <translation>Versalitas</translation>
+    </message>
+    <message>
+        <source>Capitalize</source>
+        <translation>Letra mayúscula inicial</translation>
+    </message>
+    <message>
+        <source>Case</source>
+        <translation>Empleo de mayúsculas/minúsculas</translation>
+    </message>
+    <message>
+        <source>Fixed pitch</source>
+        <translation>Monoespaciado</translation>
+    </message>
+    <message>
+        <source>Kerning</source>
+        <translation>Interletraje</translation>
+    </message>
+    <message>
+        <source>Relative</source>
+        <translation>Relativo</translation>
+    </message>
+    <message>
+        <source>Absolute</source>
+        <translation>Absoluto</translation>
+    </message>
+    <message>
+        <source>Letter spacing mode</source>
+        <translation>Modo de espaciado</translation>
+    </message>
+    <message>
+        <source>Letter spacing</source>
+        <translation>Espaciado de letras</translation>
+    </message>
+    <message>
+        <source>Word spacing</source>
+        <translation>Espaciado de palabras</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamaño</translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation>Ancho</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>Izquierdo</translation>
+    </message>
+    <message>
+        <source>Center</source>
+        <translation>Centro</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Derecho</translation>
+    </message>
+    <message>
+        <source>Justify</source>
+        <translation>Justificar</translation>
+    </message>
+    <message>
+        <source>H-Align</source>
+        <translation>Alineamiento H.</translation>
+    </message>
+    <message>
+        <source>Top</source>
+        <translation>Cima</translation>
+    </message>
+    <message>
+        <source>Bottom</source>
+        <translation>Fondo</translation>
+    </message>
+    <message>
+        <source>Left to right</source>
+        <translation>De izquierda a derecha</translation>
+    </message>
+    <message>
+        <source>Right to left</source>
+        <translation>De derecha a izquierda</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation>Automática</translation>
+    </message>
+    <message>
+        <source>none</source>
+        <translation>Ninguno</translation>
+    </message>
+    <message>
+        <source>at word boundary</source>
+        <translation>Límite de la palabra</translation>
+    </message>
+    <message>
+        <source>anywhere</source>
+        <translation>En cualquier parte</translation>
+    </message>
+    <message>
+        <source>prefer at word boundary</source>
+        <translation>Preferir el límite de la palabra</translation>
+    </message>
+    <message>
+        <source>V-Align</source>
+        <translation>Alineamiento V.</translation>
+    </message>
+    <message>
+        <source>Tab width</source>
+        <translation>Ancho de Tab</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>Texto</translation>
+    </message>
+    <message>
+        <source>Fill Random</source>
+        <translation>Rellenar aleatoriamente</translation>
+    </message>
+    <message>
+        <source>seed</source>
+        <translation>Seed</translation>
+    </message>
+    <message>
+        <source>length</source>
+        <translation>Longitud</translation>
+    </message>
+    <message>
+        <source>angle</source>
+        <translation>Ángulo</translation>
+    </message>
+    <message>
+        <source>center</source>
+        <translation>Centro</translation>
+    </message>
+    <message>
+        <source>Outline</source>
+        <translation>Trazo</translation>
+    </message>
+    <message>
+        <source>Offset</source>
+        <translation>Desplazamiento</translation>
+    </message>
+    <message>
+        <source>Reference</source>
+        <translation>Referencia</translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation>Línea</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Cerrado</translation>
+    </message>
+    <message>
+        <source>Invert</source>
+        <translation>Inverso</translation>
+    </message>
+    <message>
+        <source>rectangle</source>
+        <translation>Rectángulo</translation>
+    </message>
+    <message>
+        <source>tension</source>
+        <translation>Tensión</translation>
+    </message>
+    <message>
+        <source>output</source>
+        <translation>Output</translation>
+    </message>
+    <message>
+        <source>Page</source>
+        <translation>Página</translation>
+    </message>
+    <message>
+        <source>Solid</source>
+        <translation>Sólido</translation>
+    </message>
+    <message>
+        <source>Dashed</source>
+        <translation>Rayado</translation>
+    </message>
+    <message>
+        <source>Dotted</source>
+        <translation>Punteado</translation>
+    </message>
+    <message>
+        <source>DashDotted</source>
+        <translation>rayo/punto</translation>
+    </message>
+    <message>
+        <source>DashDotDotted</source>
+        <translation>rayo/punto/punto</translation>
+    </message>
+    <message>
+        <source>Stroke Style</source>
+        <translation>Estilo de Trazo</translation>
+    </message>
+    <message>
+        <source>Bevel</source>
+        <translation>biselada</translation>
+    </message>
+    <message>
+        <source>Miter</source>
+        <translation>ingleteada</translation>
+    </message>
+    <message>
+        <source>Round</source>
+        <translation>redonda</translation>
+    </message>
+    <message>
+        <source>Join</source>
+        <translation>Unión</translation>
+    </message>
+    <message>
+        <source>Square</source>
+        <translation>Cuadrado</translation>
+    </message>
+    <message>
+        <source>Flat</source>
+        <translation>Embutido</translation>
+    </message>
+    <message>
+        <source>Cap</source>
+        <translation>Tope</translation>
+    </message>
+    <message>
+        <source>Cosmetic</source>
+        <translation>Cosmético</translation>
+    </message>
+    <message>
+        <source>Tip</source>
+        <translation>Punta</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Ninguna</translation>
+    </message>
+    <message>
+        <source>Arrow</source>
+        <translation>Flecha</translation>
+    </message>
+    <message>
+        <source>Bar</source>
+        <translation>Barra</translation>
+    </message>
+    <message>
+        <source>Circle</source>
+        <translation>Círculo</translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation>Diamante</translation>
+    </message>
+    <message>
+        <source>Shape</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <source>Aspect Ratio</source>
+        <translation>Relación de Aspecto</translation>
+    </message>
+    <message>
+        <source>Reverse</source>
+        <translation>Invertir</translation>
+    </message>
+    <message>
+        <source>decoration</source>
+        <translation>Decoración</translation>
+    </message>
+    <message>
+        <source>this</source>
+        <translation>Este</translation>
+    </message>
+    <message>
+        <source>anchor</source>
+        <translation>Anclaje</translation>
+    </message>
+    <message>
+        <source>Symmetric</source>
+        <translation>Simétrico</translation>
+    </message>
+    <message>
+        <source>ObjectsTransformation</source>
+        <translation>Transformación de objeto</translation>
+    </message>
+</context>
+<context>
+    <name>ReferenceProperty</name>
+    <message>
+        <source>ReferenceProperty</source>
+        <translation>Atributo Referencia</translation>
+    </message>
+</context>
+<context>
+    <name>StringProperty</name>
+    <message>
+        <source>StringProperty</source>
+        <translation>Atributo Texto</translation>
+    </message>
+</context>
+<context>
+    <name>Tag</name>
+    <message>
+        <source>Tag</source>
+        <translation>Tag</translation>
+    </message>
+</context>
+<context>
+    <name>Tool</name>
+    <message>
+        <source>Tool</source>
+        <translation>Herramienta</translation>
+    </message>
+</context>
+<context>
+    <name>TriggerProperty</name>
+    <message>
+        <source>TriggerProperty</source>
+        <translation>Atributo Activador</translation>
+    </message>
+</context>
+<context>
+    <name>Unnamed Option</name>
+    <message>
+        <source>OptionsPropertyConfigWidget</source>
+        <translation>Widget de Configuración Atributo Opción</translation>
+    </message>
+</context>
+<context>
+    <name>any-context</name>
+    <message>
+        <source>undo</source>
+        <translation>Deshacer</translation>
+    </message>
+    <message>
+        <source>redo</source>
+        <translation>Rehacer</translation>
+    </message>
+    <message>
+        <source>new document</source>
+        <translation>Nuevo Documento</translation>
+    </message>
+    <message>
+        <source>save document</source>
+        <translation>Guardar</translation>
+    </message>
+    <message>
+        <source>save document as</source>
+        <translation>Guardar como ...</translation>
+    </message>
+    <message>
+        <source>load document</source>
+        <translation>Abrir ...</translation>
+    </message>
+    <message>
+        <source>export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <source>make smooth</source>
+        <translation>Ajusta tangentes de modo cúbico</translation>
+    </message>
+    <message>
+        <source>make linear</source>
+        <translation>Borrar tangentes</translation>
+    </message>
+    <message>
+        <source>remove points</source>
+        <translation>Borrar puntos</translation>
+    </message>
+    <message>
+        <source>subdivide</source>
+        <translation>Subdividir</translation>
+    </message>
+    <message>
+        <source>evaluate</source>
+        <translation>Evaluar</translation>
+    </message>
+    <message>
+        <source>show keybindings dialog</source>
+        <translation>Mostrar mapa de teclado</translation>
+    </message>
+    <message>
+        <source>restore default layout</source>
+        <translation>Revertir a la configuración de pantalla por defecto</translation>
+    </message>
+    <message>
+        <source>switch between object and point selection</source>
+        <translation>Cambiar entre la selección de objectos y puntos</translation>
+    </message>
+    <message>
+        <source>previous tool</source>
+        <translation>Herramienta previa</translation>
+    </message>
+    <message>
+        <source>select all</source>
+        <translation>Seleccionar todo</translation>
+    </message>
+    <message>
+        <source>deselect all</source>
+        <translation>Deseleccionar todo</translation>
+    </message>
+    <message>
+        <source>invert selection</source>
+        <translation>Invertir selección</translation>
+    </message>
+    <message>
+        <source>reset viewport</source>
+        <translation>Revertir vista</translation>
+    </message>
+    <message>
+        <source>show point dialog</source>
+        <translation>Mostrar diálogo para editar puntos</translation>
+    </message>
+    <message>
+        <source>remove selection</source>
+        <translation>Borrar selección</translation>
+    </message>
+    <message>
+        <source>new style</source>
+        <translation>Nuevo estilo</translation>
+    </message>
+    <message>
+        <source>convert objects</source>
+        <translation>Convertir objetos</translation>
+    </message>
+    <message>
+        <source>Cloner</source>
+        <translation>Clonador</translation>
+    </message>
+    <message>
+        <source>Ellipse</source>
+        <translation>Elipse</translation>
+    </message>
+    <message>
+        <source>Empty</source>
+        <translation>Objeto vacío</translation>
+    </message>
+    <message>
+        <source>ImageObject</source>
+        <translation>Objeto Imagen</translation>
+    </message>
+    <message>
+        <source>Instance</source>
+        <translation>Instancia</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Trayecto</translation>
+    </message>
+    <message>
+        <source>ProceduralPath</source>
+        <translation>Trayecto Procedural</translation>
+    </message>
+    <message>
+        <source>remove objects and tags</source>
+        <translation>Borrar Objetos y Tags</translation>
+    </message>
+    <message>
+        <source>ObjectManager</source>
+        <translation>Controles de Objetos</translation>
+    </message>
+    <message>
+        <source>PropertyManager</source>
+        <translation>Controles de Atributos</translation>
+    </message>
+    <message>
+        <source>PythonConsole</source>
+        <translation>Consola Python</translation>
+    </message>
+    <message>
+        <source>clear python console</source>
+        <translation>Despejar Consola Python</translation>
+    </message>
+    <message>
+        <source>StyleManager</source>
+        <translation>Controles de Estilos</translation>
+    </message>
+    <message>
+        <source>remove styles</source>
+        <translation>Borrar estilos</translation>
+    </message>
+    <message>
+        <source>Properties</source>
+        <translation>Atributos</translation>
+    </message>
+    <message>
+        <source>BrushSelectTool</source>
+        <translation>Selección con Pincel</translation>
+    </message>
+    <message>
+        <source>SelectObjectsTool</source>
+        <translation>Seleccionar objetos</translation>
+    </message>
+    <message>
+        <source>SelectPointsTool</source>
+        <translation>Seleccionar puntos</translation>
+    </message>
+    <message>
+        <source>Application</source>
+        <translation>Aplicación</translation>
+    </message>
+    <message>
+        <source>PathTag</source>
+        <translation>Tag Trayecto</translation>
+    </message>
+    <message>
+        <source>ScriptTag</source>
+        <translation>Tag Script</translation>
+    </message>
+    <message>
+        <source>StyleTag</source>
+        <translation>Tag Estilo</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation>Punto de Vista</translation>
+    </message>
+    <message>
+        <source>Mirror</source>
+        <translation>Simetrizador</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>Texto</translation>
+    </message>
+    <message>
+        <source>KnifeTool</source>
+        <translation>Cuchillo</translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation>Línea</translation>
+    </message>
+    <message>
+        <source>Outline</source>
+        <translation>Trazo</translation>
+    </message>
+    <message>
+        <source>HistoryManager</source>
+        <translation>Historia de acciones</translation>
+    </message>
+    <message>
+        <source>PathTool</source>
+        <translation>Herramienta Trayecto</translation>
+    </message>
+    <message>
+        <source>group objects</source>
+        <translation>Agrupar Objetos</translation>
+    </message>
+    <message>
+        <source>RectangleObject</source>
+        <translation>Rectángulo</translation>
+    </message>
+    <message>
+        <source>BoundingBoxManager</source>
+        <translation>Controles de Bounding Box</translation>
+    </message>
+</context>
+<context>
+    <name>menu_name</name>
+    <message>
+        <source>file</source>
+        <translation>Archivo</translation>
+    </message>
+    <message>
+        <source>edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>object</source>
+        <translation>Objeto</translation>
+    </message>
+    <message>
+        <source>create</source>
+        <translation>Crear</translation>
+    </message>
+    <message>
+        <source>attach</source>
+        <translation>Adjuntar</translation>
+    </message>
+    <message>
+        <source>scene</source>
+        <translation>Escena</translation>
+    </message>
+    <message>
+        <source>window</source>
+        <translation>Ventana</translation>
+    </message>
+    <message>
+        <source>show</source>
+        <translation>Mostrar ventana</translation>
+    </message>
+    <message>
+        <source>load recent document</source>
+        <translation>Documentos recién abridos ...</translation>
+    </message>
+    <message>
+        <source>path</source>
+        <translation>Trayecto</translation>
+    </message>
+    <message>
+        <source>tool</source>
+        <translation>Herramienta</translation>
+    </message>
+</context>
+<context>
+    <name>omm::AbstractPropertyConfigWidget</name>
+    <message>
+        <source>&amp;name:</source>
+        <translation>Nombre</translation>
+    </message>
+</context>
+<context>
+    <name>omm::Application</name>
+    <message>
+        <source>Question.</source>
+        <translation>Pregunta.</translation>
+    </message>
+    <message>
+        <source>Some pending changes will be lost if you don&apos;t save.What do you want me to do?</source>
+        <translation>Algunos cambios pendientes se van a perder si no guardas.</translation>
+    </message>
+    <message>
+        <source>Error.</source>
+        <translation>Error.</translation>
+    </message>
+    <message>
+        <source>The scene could not be saved at &apos;%1&apos;.</source>
+        <translation>La escena no se pudo guardar como &apos;%1&apos;.</translation>
+    </message>
+    <message>
+        <source>Save scene as ...</source>
+        <translation>Guardar escena como ...</translation>
+    </message>
+    <message>
+        <source>Load scene ...</source>
+        <translation>Cargar escena ...</translation>
+    </message>
+    <message>
+        <source>Loading scene from &apos;%1&apos; failed.</source>
+        <translation>La escena en &apos;%1&apos; no se pudo cargar.</translation>
+    </message>
+    <message>
+        <source>Add Tag</source>
+        <translation>Añadir día</translation>
+    </message>
+    <message>
+        <source>Create %1</source>
+        <translation>Crear %1</translation>
+    </message>
+</context>
+<context>
+    <name>omm::BoundingBoxManager</name>
+    <message>
+        <source>Bounding Box Manager</source>
+        <translation>Controles de Bounding Box</translation>
+    </message>
+    <message>
+        <source>Pos:</source>
+        <translation>Pos:</translation>
+    </message>
+    <message>
+        <source>Size:</source>
+        <translation>Tamaño:</translation>
+    </message>
+    <message>
+        <source>Points</source>
+        <translation>Puntos</translation>
+    </message>
+    <message>
+        <source>Objects</source>
+        <translation>Objetos</translation>
+    </message>
+    <message>
+        <source>World</source>
+        <translation>Mundo</translation>
+    </message>
+    <message>
+        <source>Local</source>
+        <translation>Local</translation>
+    </message>
+</context>
+<context>
+    <name>omm::ExportDialog</name>
+    <message>
+        <source>Viewport</source>
+        <translation>Vista</translation>
+    </message>
+    <message>
+        <source>Export image ...</source>
+        <translation>Exportar imagen ...</translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg)</source>
+        <translation>Imagenes (*.png *.jpg)</translation>
+    </message>
+    <message>
+        <source>Writing image &apos;%1&apos; failed.</source>
+        <translation>No se pudo guardar la imagen como &apos;%1&apos;.</translation>
+    </message>
+    <message>
+        <source>Export image</source>
+        <translation>Exportar imagen</translation>
+    </message>
+    <message>
+        <source>Export vector graphics...</source>
+        <translation>Exportar imagen vectorial ...</translation>
+    </message>
+    <message>
+        <source>SVG (*.svg)</source>
+        <translation>SVG (*.svg)</translation>
+    </message>
+</context>
+<context>
+    <name>omm::FilePathEdit</name>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+</context>
+<context>
+    <name>omm::HistoryManager</name>
+    <message>
+        <source>History</source>
+        <translation>Historia</translation>
+    </message>
+</context>
+<context>
+    <name>omm::HistoryModel</name>
+    <message>
+        <source>foundation</source>
+        <translation>Base</translation>
+    </message>
+    <message>
+        <source> #</source>
+        <translation>#</translation>
+    </message>
+</context>
+<context>
+    <name>omm::KeyBindingsDialogControls</name>
+    <message>
+        <source>Any Context</source>
+        <translation>Cualquier contexto</translation>
+    </message>
+</context>
+<context>
+    <name>omm::KeySequenceEdit</name>
+    <message>
+        <source>R</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+</context>
+<context>
+    <name>omm::MainWindow</name>
+    <message>
+        <source>About</source>
+        <translation>Sobre</translation>
+    </message>
+    <message>
+        <source>omm.</source>
+        <translation>omm.</translation>
+    </message>
+    <message>
+        <source>Changing language takes effect after restarting the application.</source>
+        <translation>Un cambio de idioma solo tiene efecto cuando reinicies la aplicación.</translation>
+    </message>
+    <message>
+        <source>information</source>
+        <translation>Información</translation>
+    </message>
+    <message>
+        <source>language</source>
+        <translation>Idioma</translation>
+    </message>
+    <message>
+        <source>system default</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>*</source>
+        <translation>*</translation>
+    </message>
+    <message>
+        <source>unnamed</source>
+        <translation>Sin nombre</translation>
+    </message>
+</context>
+<context>
+    <name>omm::PointDialog</name>
+    <message>
+        <source>Polar</source>
+        <translation>Polar</translation>
+    </message>
+    <message>
+        <source>Cartesian</source>
+        <translation>Cartesiano</translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation>Ambas</translation>
+    </message>
+</context>
+<context>
+    <name>omm::PointEdit</name>
+    <message>
+        <source>LNK</source>
+        <translation>🔗</translation>
+    </message>
+</context>
+<context>
+    <name>omm::ReferencePropertyConfigWidget</name>
+    <message>
+        <source>Tag</source>
+        <translation>Tag</translation>
+    </message>
+    <message>
+        <source>Style</source>
+        <translation>Estilo</translation>
+    </message>
+    <message>
+        <source>Object</source>
+        <translation>Objeto</translation>
+    </message>
+    <message>
+        <source>convertable</source>
+        <translation>Convertible</translation>
+    </message>
+    <message>
+        <source>has script</source>
+        <translation>Script</translation>
+    </message>
+    <message>
+        <source>is path like</source>
+        <translation>De clase Trayecto</translation>
+    </message>
+    <message>
+        <source>allowed:</source>
+        <translation>Permitido:</translation>
+    </message>
+    <message>
+        <source>required:</source>
+        <translation>Requerido:</translation>
+    </message>
+</context>
+<context>
+    <name>omm::ToolBar</name>
+    <message>
+        <source>ToolBar</source>
+        <translation>Barra de Herramientas</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Saludos! :es: 

The main part of this should be clear :) just two small notes regarding the corrections:

- f7abe63b7d66d3229cc6625c5ccb86a7c6ff0e27 fixes what to me looks like an accidental inversion of subject and object in one particular german translation, or in any case this seems to differ in meaning between the english and german translation so I think something is/was not right about this - maybe you can take a second look just to make sure I didn't "verschlimmbesser" it.

- 707554f26bd8af050c613cacc300fd2050487fb4 This removes the 'key' in 'Seed key' in one german translation because I felt Seed is probably Lehnwort enough in a german interface and 'key' maybe doesn't add much meaning there except being even more english? But feel free to kick this out if this was very intentionally translated as 'Seed key', don't mind either. :)

I'll submit another PR with translation contributor documentation later if you'd be happy to have that. :) (I know it's not exactly urgent business right now, but doesn't hurt to have it from early on either I'd say)