### PR TITLE
Add newly added libkf5itemmodels-dev package dependency to ubuntu 19.04 build instructions

### DIFF
--- a/build.md
+++ b/build.md
@@ -109,6 +109,7 @@ sudo apt install cmake
 sudo apt install pybind11-dev
 sudo apt install qtbase5-dev libqt5svg5-dev qttools5-dev  # Qt 5
 sudo apt install libpoppler-qt5-dev
+sudo apt install libkf5itemmodels-dev
 ```
 
 #### Configure, build and run


### PR DESCRIPTION
This will very soon be obsolete but as long as there is a chance someone is still using ubuntu 19.04 it might help getting them unstuck. :)