### PR TITLE
Suppress cmake policy CMP0048 warning when building with cmake 3.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required (VERSION 2.8.4)  # warnings vanish with Version > 3.3
 
+# Suppresses a warning in cmake 3.x concerning a currently unused feature (setting VERSION in project() command)
+if (POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
+endif (POLICY CMP0048)
+
 project (ommpfritt)
 
 set (CMAKE_AUTOMOC ON)


### PR DESCRIPTION
I am building with `cmake 3.13.4` and getting the following warning during running `cmake`:

```
CMake Warning (dev) at CMakeLists.txt:3 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    CMAKE_PROJECT_VERSION
    CMAKE_PROJECT_VERSION_MAJOR
    CMAKE_PROJECT_VERSION_MINOR
    CMAKE_PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```

According to my understanding and research this refers to a feature that is not used in this project (also the somewhat related custom `OMMPFRITT_VERSION_MAJOR` etc. variables as far as I can see don't get used currently). By setting the policy to `NEW` explicitly (as done in the PR) everyone who builds themselves is not getting the abovementioned and possibly confusing warning. Some empty variables (`PROJECT_VERSION_...` etc.) are set due to this change but this should have to my understanding no consequences and in any case will be the default behavior in the future.