### PR TITLE
remove all slots

### DIFF
--- a/src/animation/animator.h
+++ b/src/animation/animator.h
@@ -62,7 +62,7 @@ public:
 
   Scene& scene;
 
-public Q_SLOTS:
+public:
   void set_start(int start);
   void set_end(int end);
   void set_current(int current);

--- a/src/aspects/abstractpropertyowner.h
+++ b/src/aspects/abstractpropertyowner.h
@@ -98,7 +98,7 @@ public:
   const Kind kind;
   void new_id() const;
 
-protected Q_SLOTS:
+protected:
   virtual void on_property_value_changed(omm::Property* property)
   {
     Q_UNUSED(property);

--- a/src/keybindings/modeselector.h
+++ b/src/keybindings/modeselector.h
@@ -33,7 +33,7 @@ public:
 Q_SIGNALS:
   void mode_changed(int mode);
 
-public Q_SLOTS:
+public:
   void set_mode(int mode);
   void cycle();
 

--- a/src/mainwindow/exportdialog.h
+++ b/src/mainwindow/exportdialog.h
@@ -81,7 +81,7 @@ private:
   double compute_aspect_ratio() const;
   void update_exporter();
 
-private Q_SLOTS:
+private:
   void update_pattern_edit_background();
   void update_ending_cb();
   void reset_start_frame();

--- a/src/mainwindow/exporter.h
+++ b/src/mainwindow/exporter.h
@@ -45,7 +45,7 @@ private:
   [[nodiscard]] QString filename(int frame) const;
   void render(int frame, bool allow_overwrite);
 
-public Q_SLOTS:
+public:
   void start();
 
 Q_SIGNALS:

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -68,7 +68,7 @@ private:
 
   void handle_corrupted_config_file(const QSettings& s, const QString& what);
 
-private Q_SLOTS:
+private:
   void update_window_title();
 };
 

--- a/src/mainwindow/options.h
+++ b/src/mainwindow/options.h
@@ -25,7 +25,7 @@ public:
 
   [[nodiscard]] bool require_gui() const;
 
-public Q_SLOTS:
+public:
   void set_anchor(omm::Options::Anchor anchor);
 
 Q_SIGNALS:

--- a/src/mainwindow/toolbar/toolbaritemmodel.h
+++ b/src/mainwindow/toolbar/toolbaritemmodel.h
@@ -33,7 +33,7 @@ public:
     BadConfigurationError(const QString& description) noexcept;
   };
 
-public Q_SLOTS:
+public:
   void remove_selection(const QItemSelection& selection);
   void add_group();
   void add_separator();

--- a/src/mainwindow/viewport/anchorhud.h
+++ b/src/mainwindow/viewport/anchorhud.h
@@ -31,7 +31,7 @@ public:
 Q_SIGNALS:
   void anchor_changed(omm::Options::Anchor anchor);
 
-public Q_SLOTS:
+public:
   void set_anchor(const omm::Options::Anchor& anchor);
 
 private:

--- a/src/mainwindow/viewport/viewport.h
+++ b/src/mainwindow/viewport/viewport.h
@@ -44,7 +44,7 @@ protected:
   void keyPressEvent(QKeyEvent* event) override;
   void resizeEvent(QResizeEvent* event) override;
 
-public Q_SLOTS:
+public:
   void update();
 
 Q_SIGNALS:

--- a/src/managers/boundingboxmanager/boundingboxmanager.h
+++ b/src/managers/boundingboxmanager/boundingboxmanager.h
@@ -24,7 +24,7 @@ public:
   [[nodiscard]] QString type() const override;
   static constexpr auto TYPE = QT_TRANSLATE_NOOP("any-context", "BoundingBoxManager");
 
-public Q_SLOTS:
+public:
   void on_property_value_changed(omm::Property& property);
 
 private:
@@ -46,7 +46,7 @@ protected:
   void enterEvent(QEvent* e) override;
   bool eventFilter(QObject* o, QEvent* e) override;
 
-private Q_SLOTS:
+private:
   omm::BoundingBox update_manager();
   void update_bounding_box();
   void reset_transformation();

--- a/src/managers/curvemanager/curvemanager.h
+++ b/src/managers/curvemanager/curvemanager.h
@@ -24,7 +24,7 @@ public:
   }
   bool perform_action(const QString& name) override;
 
-public Q_SLOTS:
+public:
   void set_locked(bool locked)
   {
     m_is_locked = locked;

--- a/src/managers/curvemanager/curvemanagerwidget.h
+++ b/src/managers/curvemanager/curvemanagerwidget.h
@@ -88,7 +88,7 @@ private:
   [[nodiscard]] TangentHandle tangent_handle_at(const QPointF& point) const;
   TangentHandle m_dragged_tangent = TangentHandle();
 
-private Q_SLOTS:
+private:
   void set_selection(const std::set<AbstractPropertyOwner*>& selection);
   void add_track(omm::Track& track);
   void remove_track(omm::Track& track);

--- a/src/managers/dopesheetmanager/dopesheetview.h
+++ b/src/managers/dopesheetmanager/dopesheetview.h
@@ -17,7 +17,7 @@ class DopeSheetView : public ItemProxyView<QTreeView>
 public:
   explicit DopeSheetView(Animator& animator);
 
-public Q_SLOTS:
+public:
   void update_second_column(omm::Track& track);
   void update_second_column();
 

--- a/src/managers/manager.h
+++ b/src/managers/manager.h
@@ -47,7 +47,7 @@ private:
   using QDockWidget::setWidget;  // use set_widget instead
   bool m_is_locked = false;
 
-public Q_SLOTS:
+public:
   void set_locked(bool locked)
   {
     m_is_locked = locked;

--- a/src/managers/nodemanager/nodemanager.h
+++ b/src/managers/nodemanager/nodemanager.h
@@ -28,7 +28,7 @@ public:
 
   void set_model(NodeModel* model);
 
-public Q_SLOTS:
+public:
   void set_selection(const std::set<AbstractPropertyOwner*>& selection);
 
 private:

--- a/src/managers/nodemanager/nodescene.h
+++ b/src/managers/nodemanager/nodescene.h
@@ -35,7 +35,7 @@ public:
 
   void clear();
 
-public Q_SLOTS:
+public:
   void add_node(omm::Node& node, bool select = true);
   void remove_node(omm::Node& node);
 

--- a/src/managers/nodemanager/nodeview.h
+++ b/src/managers/nodemanager/nodeview.h
@@ -51,7 +51,7 @@ public:
   void reset_scene_rect();
   std::set<Node*> selected_nodes() const;
 
-public Q_SLOTS:
+public:
   void copy_to_clipboard() const;
   void paste_from_clipboard();
 

--- a/src/managers/objectmanager/objecttreeview.h
+++ b/src/managers/objectmanager/objecttreeview.h
@@ -27,7 +27,7 @@ public:
   [[nodiscard]] Scene& scene() const;
   static constexpr int row_height = 20;
 
-public Q_SLOTS:
+public:
   void set_selection(const std::set<AbstractPropertyOwner*>& selected_items);
   void update_tag_column_size();
 

--- a/src/managers/propertymanager/propertymanager.h
+++ b/src/managers/propertymanager/propertymanager.h
@@ -49,10 +49,10 @@ private:
   std::map<std::set<AbstractPropertyOwner*>, std::set<int>> m_current_categroy_indices;
   PropertyManagerTitleBar* m_title_bar;
 
-private Q_SLOTS:
+private:
   void activate_tabs(const std::set<int>& indices);
 
-public Q_SLOTS:
+public:
   void set_selection(const std::set<AbstractPropertyOwner*>& selection);
   void update_property_widgets();
 };

--- a/src/managers/propertymanager/userpropertydialog.h
+++ b/src/managers/propertymanager/userpropertydialog.h
@@ -22,7 +22,8 @@ public:
   explicit UserPropertyDialog(AbstractPropertyOwner& owner,
                               const std::set<QString>& disabled_types,
                               QWidget* parent = nullptr);
-public Q_SLOTS:
+
+public:
   void submit();
 
 private:

--- a/src/managers/propertymanager/userpropertylistmodel.h
+++ b/src/managers/propertymanager/userpropertylistmodel.h
@@ -38,7 +38,7 @@ public:
   [[nodiscard]] std::vector<const UserPropertyListItem*> items() const;
   bool contains(const Property* p) const;
 
-public Q_SLOTS:
+public:
   void add_property(const QString& type);
   void del_property(const QModelIndex& index);
 

--- a/src/managers/pythonconsole/pythonconsole.h
+++ b/src/managers/pythonconsole/pythonconsole.h
@@ -49,7 +49,7 @@ private:
 
   static constexpr Qt::KeyboardModifiers caption_modifiers = Qt::ControlModifier;
 
-private Q_SLOTS:
+private:
   void on_output(const void* associated_item, const QString& text, const Stream& stream);
 
 private:

--- a/src/managers/stylemanager/stylelistview.h
+++ b/src/managers/stylemanager/stylelistview.h
@@ -28,14 +28,14 @@ protected:
   void mouseDoubleClickEvent(QMouseEvent* event) override;
   void showEvent(QShowEvent* event) override;
 
-public Q_SLOTS:
+public:
   void set_selection(const std::set<Style*>& selection);
 
 private:
   const QSize m_icon_size;
   StyleListViewItemDelegate m_item_delegate;
 
-private Q_SLOTS:
+private:
   void update_layout();
 };
 

--- a/src/managers/timeline/slider.h
+++ b/src/managers/timeline/slider.h
@@ -18,7 +18,7 @@ public:
   explicit Slider(Animator& animator);
   [[nodiscard]] std::set<Track*> tracks() const;
 
-public Q_SLOTS:
+public:
   void set_range(double left, double right);
 
 Q_SIGNALS:

--- a/src/managers/timeline/timeline.h
+++ b/src/managers/timeline/timeline.h
@@ -23,7 +23,7 @@ public:
   }
   bool perform_action(const QString& name) override;
 
-public Q_SLOTS:
+public:
   void update_play_pause_button(Animator::PlayDirection direction);
 
 private:

--- a/src/managers/timeline/timelinecanvas.h
+++ b/src/managers/timeline/timelinecanvas.h
@@ -60,7 +60,7 @@ public:
    */
   virtual QRect owner_rect(AbstractPropertyOwner& owner) = 0;
 
-public Q_SLOTS:
+public:
   /**
    * @brief update issues a redraw of the gui
    */

--- a/src/nodesystem/nodecompiler.h
+++ b/src/nodesystem/nodecompiler.h
@@ -67,7 +67,7 @@ Q_SIGNALS:
   void compilation_succeeded(const QString& code);
   void compilation_failed(const QString& reason);
 
-public Q_SLOTS:
+public:
   virtual void invalidate();
 
 protected:

--- a/src/nodesystem/nodemodel.h
+++ b/src/nodesystem/nodemodel.h
@@ -90,7 +90,7 @@ public:
     NodeModel& m_model;
   };
 
-public Q_SLOTS:
+public:
   void set_error(const QString& error);
 
 Q_SIGNALS:
@@ -98,7 +98,7 @@ Q_SIGNALS:
   void node_added(omm::Node&);
   void node_removed(omm::Node&);
 
-public Q_SLOTS:
+public:
   void emit_topology_changed();
 
 private:

--- a/src/objects/instance.h
+++ b/src/objects/instance.h
@@ -45,7 +45,7 @@ private:
   bool m_cyclic_dependency = false;
   void polish();
 
-private Q_SLOTS:
+private:
   void update_tags();
 };
 

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -154,7 +154,7 @@ public:
 
   virtual void post_create_hook();
 
-public Q_SLOTS:
+public:
   virtual void update();
 
 public:

--- a/src/preferences/keybindingspage.h
+++ b/src/preferences/keybindingspage.h
@@ -37,7 +37,7 @@ private:
   std::map<QString, std::map<QString, QKeySequence>> m_revert_cache;
   void update_expand();
 
-private Q_SLOTS:
+private:
   void reset();
   void reset_filter();
   void set_name_filter(const QString& filter);

--- a/src/preferences/keybindingsproxymodel.h
+++ b/src/preferences/keybindingsproxymodel.h
@@ -15,7 +15,7 @@ public:
   [[nodiscard]] bool filterAcceptsRow(int source_row,
                                       const QModelIndex& source_parent) const override;
 
-public Q_SLOTS:
+public:
   /**
    * @brief set_action_filter the model will keep all actions where `action_name` is a part of
    *  the translated action label or key-sequence.

--- a/src/preferences/preferencedialog.h
+++ b/src/preferences/preferencedialog.h
@@ -23,7 +23,7 @@ public:
   PreferenceDialog& operator=(PreferenceDialog&&) = delete;
   PreferenceDialog& operator=(const PreferenceDialog&) = delete;
 
-public Q_SLOTS:
+public:
   void accept() override;
   void reject() override;
 

--- a/src/preferences/preferencestreeview.h
+++ b/src/preferences/preferencestreeview.h
@@ -29,7 +29,7 @@ public:
 protected:
   void resizeEvent(QResizeEvent* event) override;
 
-private Q_SLOTS:
+private:
   void update_column_width();
 
 private:

--- a/src/preferences/preferencestreeviewdelegate.h
+++ b/src/preferences/preferencestreeviewdelegate.h
@@ -13,7 +13,7 @@ public:
   void transfer_editor_data_to_model();
   void set_model(QAbstractItemModel& model);
 
-public Q_SLOTS:
+public:
   void close_current_editor();
 
 protected:

--- a/src/preferences/uicolorspage.h
+++ b/src/preferences/uicolorspage.h
@@ -28,7 +28,7 @@ public:
   void about_to_accept() override;
   void about_to_reject() override;
 
-public Q_SLOTS:
+public:
   void load_skin(int index);
 
 private:

--- a/src/properties/property.h
+++ b/src/properties/property.h
@@ -183,7 +183,8 @@ public:
 
 Q_SIGNALS:
   void enabledness_changed(bool);
-public Q_SLOTS:
+
+public:
   void set_enabledness(bool enabled);
 
 public:

--- a/src/propertywidgets/propertywidget.h
+++ b/src/propertywidgets/propertywidget.h
@@ -29,7 +29,7 @@ public:
                                   [key](const Property& p) { return p.configuration.get<T>(key); });
   }
 
-public Q_SLOTS:
+public:
   void on_property_value_changed(omm::Property* property) const;
   void update_enabledness();
 
@@ -68,7 +68,7 @@ protected:
     void remove_old_thing();
   };
 
-protected Q_SLOTS:
+protected:
   virtual void update_edit() = 0;
   virtual void update_configuration()
   {

--- a/src/renderers/style.h
+++ b/src/renderers/style.h
@@ -64,7 +64,8 @@ private:
   void update_uniform_values() const;
   std::set<Property*> m_uniform_values;
   void polish();
-private Q_SLOTS:
+
+private:
   void set_code(const QString& code) const;
   void set_error(const QString& error) const;
 };

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -59,7 +59,8 @@ public:
 
 private:
   void prepare_reset();
-public Q_SLOTS:
+
+public:
   void reset();
 
 private:
@@ -197,7 +198,8 @@ public:
   {
     return *m_tool_box;
   }
-public Q_SLOTS:
+
+public:
   void update_tool();
 
   // === Mode ===

--- a/src/tools/tool.h
+++ b/src/tools/tool.h
@@ -57,7 +57,7 @@ public:
   virtual SceneMode scene_mode() const = 0;
   static QRectF centered_rectangle(const Vec2f& center, double radius);
 
-public Q_SLOTS:
+public:
   virtual void reset()
   {
   }

--- a/src/widgets/animationbutton.h
+++ b/src/widgets/animationbutton.h
@@ -24,7 +24,7 @@ public:
   [[nodiscard]] bool has_track() const;
   [[nodiscard]] bool value_is_inconsistent() const;
 
-public Q_SLOTS:
+public:
   void set_key();
   void remove_key();
   void remove_track();

--- a/src/widgets/colorwidget/abstractcolorcomponentwidget.h
+++ b/src/widgets/colorwidget/abstractcolorcomponentwidget.h
@@ -24,7 +24,7 @@ public:
 Q_SIGNALS:
   void color_changed(const omm::Color& color);
 
-public Q_SLOTS:
+public:
   virtual void set_color(const omm::Color& color);
 
 private:

--- a/src/widgets/colorwidget/colorpicker.h
+++ b/src/widgets/colorwidget/colorpicker.h
@@ -15,7 +15,7 @@ public:
   [[nodiscard]] Color color() const;
   [[nodiscard]] virtual QString name() const = 0;
 
-public Q_SLOTS:
+public:
   virtual void set_color(const omm::Color& color);
 
 Q_SIGNALS:

--- a/src/widgets/colorwidget/colorwidget.h
+++ b/src/widgets/colorwidget/colorwidget.h
@@ -28,7 +28,7 @@ public:
   void set_compact();
   void hide_named_colors();
 
-public Q_SLOTS:
+public:
   void set_color(const omm::Color& color) override;
 
 private:
@@ -37,7 +37,7 @@ private:
   void add_color_picker(std::unique_ptr<ColorPicker> picker);
   std::map<Color::Role, std::list<AbstractColorComponentWidget*>> m_component_widgets;
 
-private Q_SLOTS:
+private:
   void show_named_colors_dialog();
 };
 

--- a/src/widgets/colorwidget/namedcolorsdialog.h
+++ b/src/widgets/colorwidget/namedcolorsdialog.h
@@ -28,7 +28,7 @@ public:
   NamedColorsDialog& operator=(NamedColorsDialog&&) = delete;
   NamedColorsDialog& operator=(const NamedColorsDialog&) = delete;
 
-public Q_SLOTS:
+public:
   static void add();
   void remove();
   void setCurrent(const QModelIndex& index);

--- a/src/widgets/combobox.h
+++ b/src/widgets/combobox.h
@@ -28,7 +28,7 @@ public:
     return m_combo_box;
   }
 
-public Q_SLOTS:
+public:
   void set_current_index(int index);
   void set_current_text(const QString& text);
 
@@ -39,7 +39,7 @@ private:
   QAbstractItemModel* m_model = nullptr;
   QComboBox* m_combo_box;
 
-private Q_SLOTS:
+private:
   void reset();
   void insert(const QModelIndex& index, int first, int last);
   void remove(const QModelIndex& index, int first, int last);

--- a/src/widgets/coordinateedit.h
+++ b/src/widgets/coordinateedit.h
@@ -27,7 +27,7 @@ Q_SIGNALS:
                          const omm::PolarCoordinates& new_val);
   void value_changed();
 
-public Q_SLOTS:
+public:
   void set_coordinates(const omm::PolarCoordinates& coordinates);
   void set_coordinates(const omm::Vec2f& coordinates);
   void set_display_mode(const omm::DisplayMode& display_mode);
@@ -44,7 +44,7 @@ private:
 
   PolarCoordinates m_old_polar_coordinates;
 
-private Q_SLOTS:
+private:
   void update_polar();
   void update_cartesian();
   void emit_value_changed();

--- a/src/widgets/multitabbar.h
+++ b/src/widgets/multitabbar.h
@@ -24,7 +24,7 @@ public:
 protected:
   bool eventFilter(QObject* o, QEvent* e) override;
 
-public Q_SLOTS:
+public:
   void set_current_indices(const std::set<int>& indices);
 
 Q_SIGNALS:

--- a/src/widgets/pointedit.h
+++ b/src/widgets/pointedit.h
@@ -31,7 +31,7 @@ private:
   Point& m_point;
   Path* m_path{};
 
-private Q_SLOTS:
+private:
   void mirror_from_right();
   void mirror_from_left();
   void set_left_maybe(const omm::PolarCoordinates& old_right,

--- a/src/widgets/referencelineedit.h
+++ b/src/widgets/referencelineedit.h
@@ -43,10 +43,10 @@ private:
   bool drag_enter(QDragEnterEvent& event);
   bool drop(QDropEvent& event);
 
-public Q_SLOTS:
+public:
   void update_candidates();
 
-private Q_SLOTS:
+private:
   void convert_text_to_placeholder_text();
 
 Q_SIGNALS:

--- a/src/widgets/treeexpandmemory.h
+++ b/src/widgets/treeexpandmemory.h
@@ -16,7 +16,7 @@ public:
   explicit TreeExpandMemory(QTreeView& view, const IndexMapper& map_to_source);
   explicit TreeExpandMemory(QTreeView& view);
 
-public Q_SLOTS:
+public:
   void restore_later();
 
 private:


### PR DESCRIPTION
They are no longer required for connections.
Regular functions have been used for connections in newer code.
slots are required only for QML and metamethod invocations, both of which are not used in this project.

Hence, the explicit `Q_SLOT` label was superfluous in the best case, its absence could have been misleading.
Consequently, the removal of the `Q_SLOT` label simplifies the code and reduces ambiguities and confusion.