### PR TITLE
replace ostream stream operators with functions `to_string()`

### DIFF
--- a/src/aspects/abstractpropertyowner.cpp
+++ b/src/aspects/abstractpropertyowner.cpp
@@ -150,17 +150,6 @@ std::unique_ptr<Property> AbstractPropertyOwner::extract_property(const QString&
   return property;
 }
 
-std::ostream& operator<<(std::ostream& ostream, const AbstractPropertyOwner* apo)
-{
-  if (apo == nullptr) {
-    ostream << "AbstractPropertyOwner[nullptr]";
-  } else {
-    const auto kind = static_cast<std::underlying_type_t<decltype(apo->kind)>>(apo->kind);
-    ostream << "AbstractPropertyOwner[" << kind << "]";
-  }
-  return ostream;
-}
-
 void AbstractPropertyOwner::copy_properties(AbstractPropertyOwner& target,
                                             CopiedProperties flags) const
 {
@@ -206,6 +195,11 @@ void AbstractPropertyOwner::new_id() const
   static std::mt19937 gen(rd());  // Standard mersenne_twister_engine seeded with rd()
   static std::uniform_int_distribution<std::size_t> dis(1, std::numeric_limits<std::size_t>::max());
   m_id = dis(gen);
+}
+
+QString AbstractPropertyOwner::to_string() const
+{
+  return QString{"%1[]"}.arg(type());
 }
 
 bool AbstractPropertyOwner::pmatch(const Property* property, const std::set<QString>& keys) const

--- a/src/aspects/abstractpropertyowner.h
+++ b/src/aspects/abstractpropertyowner.h
@@ -98,6 +98,8 @@ public:
   const Kind kind;
   void new_id() const;
 
+  virtual QString to_string() const;
+
 protected:
   virtual void on_property_value_changed(omm::Property* property)
   {

--- a/src/aspects/propertyowner.h
+++ b/src/aspects/propertyowner.h
@@ -13,8 +13,6 @@ public:
   static constexpr Kind KIND = kind_;
 };
 
-std::ostream& operator<<(std::ostream& ostream, const AbstractPropertyOwner* apo);
-
 template<typename T, typename S> T kind_cast(S s)
 {
   if (s != nullptr && s->kind == std::remove_pointer_t<T>::KIND) {

--- a/src/aspects/serializable.h
+++ b/src/aspects/serializable.h
@@ -35,9 +35,7 @@ public:
   template<typename PointerT> static QString make_pointer(const PointerT& pointer)
   {
     constexpr char SEPARATOR = '/';
-    std::ostringstream ostream;
-    ostream << pointer;
-    auto str = QString::fromStdString(ostream.str());
+    auto str = QString{"%1"}.arg(pointer);
     assert(str.size() > 0);
     if (str.at(0) == SEPARATOR) {
       return str;

--- a/src/aspects/treeelement.cpp
+++ b/src/aspects/treeelement.cpp
@@ -143,22 +143,6 @@ template<typename T> std::vector<T*> TreeElement<T>::sort(const std::set<T*>& it
   return vs;
 }
 
-std::ostream& operator<<(std::ostream& ostream, const TreeTestItem* item)
-{
-  if (item == nullptr) {
-    ostream << "Item[nullptr]";
-  } else {
-    ostream << "Item[" << item->name << "]";
-  }
-  return ostream;
-}
-
-std::ostream& operator<<(std::ostream& ostream, const TreeTestItem& item)
-{
-  ostream << &item;
-  return ostream;
-}
-
 template class TreeElement<Object>;
 template class TreeElement<TreeTestItem>;
 

--- a/src/aspects/treeelement.h
+++ b/src/aspects/treeelement.h
@@ -104,23 +104,23 @@ template<typename T> bool tree_gt(const T* a, const T* b)
 }
 
 template<typename T>
-std::ostream& print_tree(std::ostream& ostream, const T* item, int indentation = 0)
+void print_tree(QString& buffer, const T* item, int indentation = 0)
 {
-  ostream << QString(" ").repeated(indentation).toStdString() << item << "\n";
+  const auto sitem = item == nullptr ? QString{"[null]"} : item->to_string();
+  buffer += QString(" ").repeated(indentation).toStdString() + sitem + "\n";
   if (item != nullptr) {
     const auto children = item->tree_children();
     const auto is_pre_leaf = std::none_of(children.begin(), children.end(), [](auto* c) {
       return c->tree_children().size() > 0;
     });
     if (is_pre_leaf) {
-      ::operator<<(ostream, children);
+      buffer += children;
     } else {
       for (auto&& child : item->tree_children()) {
-        print_tree(ostream, child, indentation + 2);
+        print_tree(buffer, child, indentation + 2);
       }
     }
   }
-  return ostream;
 }
 
 /**
@@ -134,8 +134,5 @@ class TreeTestItem : public TreeElement<TreeTestItem>
 public:
   QString name;
 };
-
-std::ostream& operator<<(std::ostream& ostream, const TreeTestItem* item);
-std::ostream& operator<<(std::ostream& ostream, const TreeTestItem& item);
 
 }  // namespace omm

--- a/src/color/color.cpp
+++ b/src/color/color.cpp
@@ -433,23 +433,22 @@ bool operator<(const Color& a, const Color& b)
   }
 }
 
-std::ostream& operator<<(std::ostream& ostream, const Color& color)
+QString Color::to_string() const
 {
-  const QString id = [color]() {
-    if (color.model() == Color::Model::Named) {
-      return color.name();
+  const QString id = [this]() {
+    if (model() == Color::Model::Named) {
+      return name();
     } else {
       QStringList cs;
-      const auto components = color.components(color.model());
+      const auto components = this->components(model());
       for (std::size_t i = 0; i < components.size(); ++i) {
-        const auto component_name = Color::component_name(color.model(), i);
+        const auto component_name = Color::component_name(model(), i);
         cs.append(QString("%1: %2").arg(component_name, components.at(i)));
       }
       return cs.join(", ");
     }
   }();
-  ostream << QString("Color[%1]").arg(id).toStdString();
-  return ostream;
+  return QString("Color[%1]").arg(id);
 }
 
 }  // namespace omm

--- a/src/color/color.h
+++ b/src/color/color.h
@@ -49,6 +49,8 @@ public:
     return m_current_model;
   }
 
+  QString to_string() const;
+
 private:
   Model m_current_model;
   QString m_name = "";
@@ -81,6 +83,5 @@ static const Color CERULEAN(Color::Model::RGBA, {0.1, 0.52, 0.82, 1.0});
 bool operator==(const Color& a, const Color& b);
 bool operator!=(const Color& a, const Color& b);
 bool operator<(const Color& a, const Color& b);
-std::ostream& operator<<(std::ostream& ostream, const Color& color);
 
 }  // namespace omm

--- a/src/color/namedcolors.cpp
+++ b/src/color/namedcolors.cpp
@@ -1,8 +1,6 @@
 #include "color/namedcolors.h"
 #include "logging.h"
 #include "serializers/abstractserializer.h"
-#include <iomanip>
-#include <ostream>
 
 namespace omm
 {

--- a/src/dnf.h
+++ b/src/dnf.h
@@ -104,6 +104,22 @@ public:
     return static_cast<E>(1 << i);
   }
 
+  QString to_string() const
+  {
+    QString s;
+    if (!value) {
+      s += "¬";
+    }
+    if constexpr (std::is_enum_v<E>) {
+      s += QString("%1").arg(static_cast<std::underlying_type_t<E>>(i));
+    } else {
+      s += QString("%1").arg(value);
+    }
+
+    return s;
+  }
+
+
   std::size_t i = -1;
   bool value = false;
 };
@@ -171,6 +187,22 @@ public:
                                         other.terms.end());
   }
 
+  QString to_string() const
+  {
+    QString s;
+    s += "( ";
+    auto it = terms.begin();
+    while (it != terms.end()) {
+      if (it != terms.begin()) {
+        s += QString{" %1 "}.arg(Junction::operator_symbol);
+      }
+      s += it->to_string();
+      it++;
+    }
+    s += ") ";
+    return s;
+  }
+
   std::set<T> terms;
 };
 
@@ -181,35 +213,5 @@ using Conjunction = DNF_detail::Term<E, T, DNF_detail::ConjunctionImpl<T>>;
 template<typename E, typename T = Literal<E>>
 using Disjunction = DNF_detail::Term<E, T, DNF_detail::DisjunctionImpl<T>>;
 template<typename E> using DNF = Disjunction<E, Conjunction<E>>;
-
-template<typename E, typename T, typename Junction>
-std::ostream& operator<<(std::ostream& ostream, const DNF_detail::Term<E, T, Junction>& dnf)
-{
-  ostream << "( ";
-  auto it = dnf.terms.begin();
-  while (it != dnf.terms.end()) {
-    if (it != dnf.terms.begin()) {
-      ostream << " " << Junction::operator_symbol << " ";
-    }
-    ostream << *it;
-    it++;
-  }
-  ostream << ") ";
-  return ostream;
-}
-
-template<typename E> std::ostream& operator<<(std::ostream& ostream, const Literal<E>& literal)
-{
-  if (!literal.value) {
-    ostream << "¬";
-  }
-  if constexpr (std::is_enum_v<E>) {
-    ostream << static_cast<std::underlying_type_t<E>>(literal.i);
-  } else {
-    ostream << static_cast<E>(literal);
-  }
-
-  return ostream;
-}
 
 }  // namespace omm

--- a/src/geometry/boundingbox.cpp
+++ b/src/geometry/boundingbox.cpp
@@ -82,10 +82,9 @@ bool BoundingBox::contains(const BoundingBox& other) const
   }
 }
 
-std::ostream& operator<<(std::ostream& ostream, const BoundingBox& bb)
+QString BoundingBox::to_string() const
 {
-  ostream << "BoundingBox[" << bb.top_left() << ", " << bb.width() << "x" << bb.height() << "]";
-  return ostream;
+  return QString{"BoundingBox[%1, %2]"}.arg(top_left().to_string()).arg(bottom_right().to_string());
 }
 
 BoundingBox& BoundingBox::operator|=(const BoundingBox& other)

--- a/src/geometry/boundingbox.h
+++ b/src/geometry/boundingbox.h
@@ -26,9 +26,9 @@ public:
   BoundingBox& operator|=(const Vec2f& point);
 
   static BoundingBox around_selected_objects(const Scene& scene);
+  QString to_string() const;
 };
 
-std::ostream& operator<<(std::ostream& ostream, const BoundingBox& bb);
 BoundingBox operator|(const BoundingBox& a, const BoundingBox& b);
 BoundingBox operator|(const BoundingBox& a, const Vec2f& b);
 

--- a/src/geometry/objecttransformation.cpp
+++ b/src/geometry/objecttransformation.cpp
@@ -2,7 +2,6 @@
 #include <QTransform>
 #include <cassert>
 #include <cmath>
-#include <ostream>
 
 #include "geometry/objecttransformation.h"
 
@@ -171,14 +170,12 @@ Vec2f ObjectTransformation::null() const
   return apply_to_position(Vec2f::o());
 }
 
-QDebug& operator <<(QDebug& ostream, const ObjectTransformation& t)
+QString ObjectTransformation::to_string() const
 {
-  ostream << "[ t(" << t.translation().x << ", " << t.translation().y;
-  ostream << ") s(" << t.scaling().x << ", " << t.scaling().y;
-  ostream << ") sh(" << t.shearing();
-  static constexpr double degree_radians_factor = M_180_PI;
-  ostream << ") r(" << t.rotation() * degree_radians_factor << ") ]";
-  return ostream;
+  return QString{"[t=%1, s=%2, sh=%3, r=%4°]"}.arg(translation().to_string())
+                                              .arg(scaling().to_string())
+                                              .arg(shearing())
+                                              .arg(M_180_PI * rotation());
 }
 
 bool operator==(const ObjectTransformation& lhs, const ObjectTransformation& rhs)

--- a/src/geometry/objecttransformation.h
+++ b/src/geometry/objecttransformation.h
@@ -71,6 +71,8 @@ public:
   [[nodiscard]] std::unique_ptr<Geom::Curve> apply(const Geom::Curve& curve) const;
   operator Geom::Affine() const;
 
+  QString to_string() const;
+
 private:
   Vec2f m_translation = {0.0, 0.0};
   Vec2f m_scaling = {1.0, 1.0};
@@ -83,7 +85,6 @@ private:
                                                 const Geom::Affine& affine);
 };
 
-QDebug& operator<<(QDebug& ostream, const ObjectTransformation& t);
 bool operator<(const ObjectTransformation& lhs, const ObjectTransformation& rhs);
 bool operator==(const ObjectTransformation& lhs, const ObjectTransformation& rhs);
 bool operator!=(const ObjectTransformation& lhs, const ObjectTransformation& rhs);

--- a/src/geometry/point.cpp
+++ b/src/geometry/point.cpp
@@ -2,7 +2,6 @@
 #include "logging.h"
 #include "serializers/abstractserializer.h"
 #include <cmath>
-#include <ostream>
 
 namespace omm
 {
@@ -23,6 +22,7 @@ Point::Point(const Vec2f& position, const double rotation, const double tangent_
 Point::Point(const Vec2f& position) : Point(position, 0.0, 0.0)
 {
 }
+
 Point::Point() : Point(Vec2f::o())
 {
 }
@@ -108,32 +108,16 @@ Point Point::flattened(const double t) const
   return copy;
 }
 
-std::ostream& operator<<(std::ostream& ostream, const PolarCoordinates& pc)
-{
-  ostream << "[phi=" << pc.argument << ", r=" << pc.magnitude << "]";
-  return ostream;
-}
-
-std::ostream& operator<<(std::ostream& ostream, const Point& pc)
+QString Point::to_string() const
 {
   static constexpr bool verbose = false;
   if constexpr (verbose) {
-    ostream << "Point[[" << pc.position.x << ", " << pc.position.y << "], " << pc.left_tangent
-            << ", " << pc.right_tangent << "]";
+    return QString{"Point[%1, %2, %3]"}.arg(position.to_string(),
+                                            left_tangent.to_string(),
+                                            right_tangent.to_string());
   } else {
-    ostream << "[" << pc.position.x << ", " << pc.position.y << "]";
+    return QString{"[%1]"}.arg(position.to_string());
   }
-  return ostream;
-}
-
-std::ostream& operator<<(std::ostream& ostream, const Point* pc)
-{
-  if (pc == nullptr) {
-    ostream << "Point[nullptr]";
-  } else {
-    ostream << *pc;
-  }
-  return ostream;
 }
 
 bool Point::operator==(const Point& point) const

--- a/src/geometry/point.h
+++ b/src/geometry/point.h
@@ -75,14 +75,11 @@ private:
 
 public:
   static std::vector<Point> offset(double t, const std::vector<Point>& points, bool is_closed);
+  QString to_string() const;
 };
 
 constexpr PolarCoordinates to_polar(Vec2f cartesian);
 constexpr Vec2f to_cartesian(const PolarCoordinates& polar);
-
-std::ostream& operator<<(std::ostream& ostream, const PolarCoordinates& pc);
-std::ostream& operator<<(std::ostream& ostream, const Point& pc);
-std::ostream& operator<<(std::ostream& ostream, const Point* pc);
 
 bool fuzzy_eq(const Point& a, const Point& b);
 

--- a/src/geometry/polarcoordinates.cpp
+++ b/src/geometry/polarcoordinates.cpp
@@ -67,4 +67,9 @@ double PolarCoordinates::normalize_angle(double rad)
   return fmod(fmod(rad + M_PI, pi2) + pi2, pi2) - M_PI;
 }
 
+QString PolarCoordinates::to_string() const
+{
+  return QString{"[%1°, %2]"}.arg(argument * 180.0 / M_PI).arg(magnitude);
+}
+
 }  // namespace omm

--- a/src/geometry/polarcoordinates.h
+++ b/src/geometry/polarcoordinates.h
@@ -30,6 +30,8 @@ struct PolarCoordinates {
    * @return an number between [-pi, pi)
    */
   static double normalize_angle(double rad);
+
+  QString to_string() const;
 };
 
 }  // namespace omm

--- a/src/geometry/vec2.h
+++ b/src/geometry/vec2.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <QPointF>
+#include <QString>
 #include <algorithm>
 #include <array>
 #include <cmath>
-#include <ostream>
 #include <stdexcept>
 #include <vector>
 
@@ -192,6 +192,11 @@ public:
   {
     return std::isinf(x) || std::isinf(y);
   }
+
+  QString to_string() const
+  {
+    return QString{"[%1, %2]"}.arg(x).arg(y);
+  }
 };
 
 template<typename ValueT> Vec2<ValueT> operator-(const Vec2<ValueT>& d)
@@ -269,12 +274,6 @@ template<typename ValueT> bool operator<(const Vec2<ValueT>& d1, const Vec2<Valu
 
 using Vec2f = Vec2<double>;
 using Vec2i = Vec2<int>;
-
-template<typename T> std::ostream& operator<<(std::ostream& ostream, const Vec2<T>& vec)
-{
-  ostream << "[" << vec.x << ", " << vec.y << "]";
-  return ostream;
-}
 
 template<typename T> bool fuzzy_eq(const Vec2<T>& a, const Vec2<T>& b)
 {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -5,15 +5,8 @@
 #include <QFile>
 #include <QStandardPaths>
 #include <ctime>
-#include <iomanip>
 #include <iostream>
 #include "config.h"
-
-QDebug operator<<(QDebug d, const std::string& string)
-{
-  d << QString::fromStdString(string);
-  return d;
-}
 
 namespace omm
 {

--- a/src/logging.h
+++ b/src/logging.h
@@ -60,34 +60,3 @@ void handle_log(QFile& logfile,
 void setup_logfile(QFile& logfile);
 
 }  // namespace omm
-
-template<template<typename> typename ContainerT, typename T>
-void stream_container(QDebug& ostream, const ContainerT<T>& vs, const QString& container_name)
-{
-  ostream << container_name << "(" << vs.size() << ")[";
-  for (auto it = vs.cbegin(); it != vs.cend(); ++it) {
-    if (it != vs.cbegin()) {
-      ostream << ", ";
-    }
-    ostream << *it;
-  }
-  ostream << "]";
-}
-
-template<typename T> QDebug operator<<(QDebug ostream, const std::vector<T>& vs)
-{
-  stream_container<std::vector, T>(ostream, vs, "vector");
-  return ostream;
-}
-
-template<typename T> QDebug operator<<(QDebug ostream, const std::set<T>& vs)
-{
-  stream_container<std::set, T>(ostream, vs, "set");
-  return ostream;
-}
-
-template<typename... T> QDebug operator<<(QDebug ostream, const std::unique_ptr<T...>& uptr)
-{
-  ostream << *uptr;
-  return ostream;
-}

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -40,8 +40,9 @@ int main(int argc, char* argv[])
   level = args.get<QString>(CommandLineParser::VERBOSITY_KEY);
   if (!::contains(omm::LogLevel::loglevels, level)) {
     const auto levels = ::transform<QString, QList>(::get_keys(omm::LogLevel::loglevels));
-    std::cerr << "Unknown log level '" << level << "'. Use " << levels.join("|") << ".\n";
-    std::cerr << std::flush;
+    std::cerr << "Unknown log level '" << level.toStdString()
+              << "'. Use " << levels.join("|").toStdString() << ".\n"
+              << std::flush;
     exit(EXIT_FAILURE);
   }
 
@@ -65,7 +66,7 @@ int main(int argc, char* argv[])
   } else if (mode == CommandLineParser::RENDER_MODE_NAME) {
     return omm::render_main(args, app);
   } else {
-    std::cerr << "Unexpected mode: " << mode << "." << std::endl;
+    std::cerr << "Unexpected mode: " << mode.toStdString() << "." << std::endl;
     return EXIT_FAILURE;
   }
 }

--- a/src/managers/propertymanager/propertymanager.cpp
+++ b/src/managers/propertymanager/propertymanager.cpp
@@ -84,18 +84,6 @@ QString get_tab_label(const std::map<omm::AbstractPropertyOwner*, omm::Property*
   return tab_label;
 }
 
-QString join(const std::list<QString>& strings, const QString& separator)
-{
-  if (strings.empty()) {
-    return "";
-  }
-  QString joined = strings.front();
-  for (auto it = std::next(strings.begin()); it != strings.end(); ++it) {
-    joined += separator + *it;
-  }
-  return joined;
-}
-
 }  // namespace
 
 namespace omm
@@ -189,8 +177,9 @@ void PropertyManager::set_selection(const std::set<AbstractPropertyOwner*>& sele
           = ::transform<QString, std::list>(selection, [](AbstractPropertyOwner* owner) {
               return owner->name();
             });
-      tokens.push_back("[" + join(names, ", ") + "]");
-      m_selection_label->setText(join(tokens, " "));
+      static constexpr auto s2s = [](const QString& s) { return s; };
+      tokens.push_back("[" + join(names, s2s) + "]");
+      m_selection_label->setText(join(tokens, s2s));
 
       // text in m_selection_label can get huge but is not very important. Don't mess up the layout.
       m_selection_label->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);

--- a/src/managers/propertymanager/userpropertydialog.cpp
+++ b/src/managers/propertymanager/userpropertydialog.cpp
@@ -5,8 +5,6 @@
 #include "propertywidgets/propertyconfigwidget.h"
 #include "scene/history/historymodel.h"
 #include "scene/scene.h"
-#include <iomanip>
-#include <ostream>
 
 namespace omm
 {

--- a/src/nodesystem/statement.cpp
+++ b/src/nodesystem/statement.cpp
@@ -74,16 +74,14 @@ bool Statement::operator<(const Statement& other) const
   }
 }
 
-std::ostream& operator<<(std::ostream& ostream, const Statement& statement)
+QString Statement::to_string() const
 {
   const auto format = [](const auto& set) -> QStringList {
     return ::transform<QString, QList>(set, [](const auto* port) { return port->uuid(); });
   };
-  ostream << QString("%1[%2 <= %3]")
-                 .arg(statement.is_connection() ? "connection" : "node",
-                      format(statement.defines()).join(", "),
-                      format(statement.uses()).join(", "))
-                 .toStdString();
-  return ostream;
+  return QString("%1[%2 <= %3]")
+                 .arg(is_connection() ? "connection" : "node",
+                      format(defines()).join(", "),
+                      format(uses()).join(", "));
 }
 }  // namespace omm

--- a/src/nodesystem/statement.h
+++ b/src/nodesystem/statement.h
@@ -24,6 +24,7 @@ public:
   [[nodiscard]] virtual bool is_connection() const = 0;
   [[nodiscard]] virtual std::set<const AbstractPort*> defines() const = 0;
   [[nodiscard]] virtual std::set<const AbstractPort*> uses() const = 0;
+  QString to_string() const;
 };
 
 class NodeStatement : public Statement

--- a/src/objects/object.cpp
+++ b/src/objects/object.cpp
@@ -233,20 +233,9 @@ void Object::set_virtual_parent(const Object* parent)
   m_virtual_parent = parent;
 }
 
-std::ostream& operator<<(std::ostream& ostream, const Object& object)
+QString Object::to_string() const
 {
-  ostream << object.type() << "[" << object.name() << "]";
-  return ostream;
-}
-
-std::ostream& operator<<(std::ostream& ostream, const Object* object)
-{
-  if (object != nullptr) {
-    ostream << *object;
-  } else {
-    ostream << "null-Object";
-  }
-  return ostream;
+  return QString("%1[%2]").arg(type(), name());
 }
 
 void Object::serialize(AbstractSerializer& serializer, const Pointer& root) const

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -176,6 +176,8 @@ public:
   void set_position_on_path(const Object& path, bool align, const Geom::PathVectorTime& t);
   void set_oriented_position(const Point& op, bool align);
 
+  QString to_string() const override;
+
 private:
   ObjectTree* m_object_tree = nullptr;
   const Object* m_virtual_parent = nullptr;
@@ -197,8 +199,5 @@ protected:
     return paths;
   }
 };
-
-std::ostream& operator<<(std::ostream& ostream, const Object& object);
-std::ostream& operator<<(std::ostream& ostream, const Object* object);
 
 }  // namespace omm

--- a/src/preferences/uicolors.cpp
+++ b/src/preferences/uicolors.cpp
@@ -10,7 +10,6 @@
 #include <QSettings>
 #include <QStyleFactory>
 #include <QWidget>
-#include <iostream>
 
 namespace
 {

--- a/src/properties/propertyfilter.cpp
+++ b/src/properties/propertyfilter.cpp
@@ -57,9 +57,8 @@ PropertyFilter PropertyFilter::accept_anything()
   return PropertyFilter(Disjunction<Kind>(Kind::All, Kind::None), {{}});
 }
 
-std::ostream& operator<<(std::ostream& ostream, const PropertyFilter& filter)
+QString PropertyFilter::to_string() const
 {
-  ostream << "Filter(Flag(" << filter.flag << "), Kind(" << filter.kind << "))";
-  return ostream;
+  return QString{"Filter[Flag=%1, Kind=%2]"}.arg(flag.to_string()).arg(kind.to_string());
 }
 }  // namespace omm

--- a/src/properties/propertyfilter.h
+++ b/src/properties/propertyfilter.h
@@ -24,8 +24,7 @@ struct PropertyFilter : public Serializable {
   bool operator<(const PropertyFilter& other) const;
 
   static PropertyFilter accept_anything();
+  QString to_string() const;
 };
-
-std::ostream& operator<<(std::ostream& ostream, const PropertyFilter& filter);
 
 }  // namespace omm

--- a/src/python/propertyownerwrapper.h
+++ b/src/python/propertyownerwrapper.h
@@ -70,7 +70,8 @@ public:
   {
     std::ostringstream ostream;
     const auto* apo = &this->wrapped;
-    ostream << enum_name(apo->kind, true) << "[" << static_cast<const void*>(apo) << "]";
+    ostream << enum_name(apo->kind, true).toStdString()
+            << "[" << static_cast<const void*>(apo) << "]";
     return ostream.str();
   }
 

--- a/src/python/pythonengine.cpp
+++ b/src/python/pythonengine.cpp
@@ -6,7 +6,6 @@
 #include "scene/scene.h"
 #include "tags/scripttag.h"
 #include <functional>
-#include <iostream>
 
 namespace py = pybind11;
 

--- a/src/renderers/styleiconengine.cpp
+++ b/src/renderers/styleiconengine.cpp
@@ -2,7 +2,6 @@
 #include "preferences/uicolors.h"
 #include "renderers/painter.h"
 #include <QPainter>
-#include <iostream>
 #include <memory>
 
 namespace

--- a/src/splinetype.cpp
+++ b/src/splinetype.cpp
@@ -67,6 +67,12 @@ const std::map<SpInit, omm::SplineType::knot_map_type> predefined{
 
 namespace omm
 {
+
+QString SplineType::to_string() const
+{
+  return {};
+}
+
 SplineType::ControlPoint SplineType::begin()
 {
   return ControlPoint(knots, knots.begin(), Knot::Side::Middle);

--- a/src/splinetype.h
+++ b/src/splinetype.h
@@ -29,6 +29,8 @@ public:
   using knot_map_type = std::multimap<double, Knot>;
   knot_map_type knots;
 
+  QString to_string() const;
+
 private:
   template<typename Knots, typename Iterator> struct ControlPoint_ {
     using Side = Knot::Side;

--- a/src/tags/tag.cpp
+++ b/src/tags/tag.cpp
@@ -23,10 +23,9 @@ Tag::~Tag()
   assert(!::contains(owner->scene()->selection(), this));
 }
 
-std::ostream& operator<<(std::ostream& ostream, const Tag& tag)
+QString Tag::to_string() const
 {
-  ostream << tag.type() << "[" << tag.name() << "]";
-  return ostream;
+  return QString{"%1[%2]"}.arg(type(), name());
 }
 
 Flag Tag::flags() const

--- a/src/tags/tag.h
+++ b/src/tags/tag.h
@@ -36,8 +36,7 @@ public:
     evaluate();
   }
   Flag flags() const override;
+  QString to_string() const override;
 };
-
-std::ostream& operator<<(std::ostream& ostream, const Tag& tag);
 
 }  // namespace omm

--- a/src/variant.h
+++ b/src/variant.h
@@ -160,7 +160,4 @@ double get_channel_value(const variant_type& variant, std::size_t channel);
  */
 void set_channel_value(variant_type& variant, std::size_t channel, double value);
 
-std::ostream& operator<<(std::ostream& ostream, const TriggerPropertyDummyValueType& v);
-std::ostream& operator<<(std::ostream& ostream, const variant_type& v);
-
 }  // namespace omm

--- a/test/unit/geometry.cpp
+++ b/test/unit/geometry.cpp
@@ -58,8 +58,8 @@ bool check_transform_to_mat_to_transform_invariant(SetParameterF<Arg> f, const A
     // LOG(INFO) << "pass " << typeid(f).name() << " [" << arg << "]";
     return true;
   } else {
-    LINFO << "expected: \n" << reference;
-    LINFO << "but got: \n" << other;
+    LINFO << "expected: \n" << reference.to_string();
+    LINFO << "but got: \n" << other.to_string();
     // LOG(WARNING) << "fail " << typeid(f).name() << " [" << arg << "]";
     return false;
   }

--- a/test/unit/tree.cpp
+++ b/test/unit/tree.cpp
@@ -92,8 +92,9 @@ TEST(tree, remove_children)
           auto candidates = get_items(items, candidate_names);
           omm::TreeTestItem::remove_internal_children(candidates);
           const auto gt_items = get_items(items, gt_names);
-          std::cout << "Expected: " << gt_items << std::endl;
-          std::cout << "Actual:   " << candidates << std::endl;
+          static constexpr auto to_string = [](const auto* i) { return i->name; };
+          std::cout << "Expected: " << join(gt_items, to_string).toStdString() << std::endl;
+          std::cout << "Actual:   " << join(candidates, to_string).toStdString() << std::endl;
           EXPECT_EQ(candidates, gt_items);
         };
 


### PR DESCRIPTION
The stream operators overloads were convenient but also complicated and fragile.
They caused a lot of maintenance overhead.
Compilation failed quite often because some new type causes overloads to become ambiguous or invalid..
Finding and fixing such errors is cumbersome, the error messages are long and cryptic.
Even worse: compilers behave differently quite often (e.g., GCC compiles but clang doesn't), which indicates that the code is at the fringe of or maybe even beyond the standard.

The new concept uses `to_string` class members.
They need to be called explicitly, which means a little more typing effort.
However, the code is now more direct.