### PR TITLE
Implement n-joints

### DIFF
--- a/keybindings/default_keybindings.cfg
+++ b/keybindings/default_keybindings.cfg
@@ -40,6 +40,8 @@ select connected points:
 fill selection:
 extend selection:
 shrink selection:
+join points:
+disjoin points:
 
 # Managers:
 BoundingBoxManager:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(libommpfritt PRIVATE
   common.h
   enumnames.cpp
   enumnames.h
+  disjointset.h
   dnf.cpp
   dnf.h
   logging.cpp

--- a/src/commands/CMakeLists.txt
+++ b/src/commands/CMakeLists.txt
@@ -8,6 +8,8 @@ target_sources(libommpfritt PRIVATE
   copycommand.h
   cutpathcommand.cpp
   cutpathcommand.h
+  joinpointscommand.cpp
+  joinpointscommand.h
   keyframecommand.cpp
   keyframecommand.h
   modifypointscommand.cpp

--- a/src/commands/joinpointscommand.cpp
+++ b/src/commands/joinpointscommand.cpp
@@ -1,0 +1,70 @@
+#include "commands/joinpointscommand.h"
+
+namespace omm
+{
+
+JoinPointsCommand::JoinPointsCommand(const Map& map)
+  : Command(QObject::tr("Join Points"))
+  , m_points(map)
+{
+}
+
+void JoinPointsCommand::undo()
+{
+  for (auto&& [path, points] : m_points) {
+    path->m_joined_points = m_old_forest[path];
+    for (auto it : points) {
+      *it = m_old_positions[it];
+    }
+    path->update();
+  }
+}
+
+void JoinPointsCommand::redo()
+{
+  for (auto&& [path, point_iterators] : m_points) {
+    m_old_forest[path] = path->m_joined_points;
+    const auto joined = path->join_points(point_iterators);
+    const auto new_pos = compute_position(joined);
+    for (const auto& it : point_iterators) {
+      m_old_positions[it] = *it;
+      it->set_position(new_pos);
+    }
+    path->update();
+  }
+}
+
+Vec2f JoinPointsCommand::compute_position(const std::set<Point*>& points)
+{
+  Vec2f pos{0.F, 0.F};
+  for (const auto* p : points) {
+    pos += p->position();
+  }
+  return pos / static_cast<double>(points.size());
+}
+
+DisjoinPointsCommand::DisjoinPointsCommand(const Map& map)
+  : Command(QObject::tr("Disjoin Points"))
+  , m_points(map)
+{
+}
+
+void DisjoinPointsCommand::undo()
+{
+  for (auto&& [path, points] : m_points) {
+    path->m_joined_points = m_old_forest[path];
+    path->update();
+  }
+}
+
+void DisjoinPointsCommand::redo()
+{
+  for (auto&& [path, point_iterators] : m_points) {
+    m_old_forest[path] = path->m_joined_points;
+    for (const auto& it : point_iterators) {
+      path->disjoin_points(it);
+    }
+  }
+}
+
+}  // namespace omm

--- a/src/commands/joinpointscommand.h
+++ b/src/commands/joinpointscommand.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "commands/command.h"
+#include "objects/path.h"
+
+#include <vector>
+#include <map>
+
+namespace omm
+{
+
+class JoinPointsCommand : public Command
+{
+public:
+  using Map = std::map<Path*, std::set<Point*>>;
+  explicit JoinPointsCommand(const Map& map);
+  void undo() override;
+  void redo() override;
+
+private:
+  const std::map<Path*, std::set<Point*>> m_points;
+  std::map<Path*, DisjointSetForest<Point*>> m_old_forest;
+  std::map<Point*, Point> m_old_positions;
+
+  static Vec2f compute_position(const std::set<Point*>& points);
+};
+
+class DisjoinPointsCommand : public Command
+{
+public:
+  using Map = std::map<Path*, std::set<Point*>>;
+  explicit DisjoinPointsCommand(const Map& map);
+  void undo() override;
+  void redo() override;
+
+private:
+  const std::map<Path*, std::set<Point*>> m_points;
+  std::map<Path*, DisjointSetForest<Point*>> m_old_forest;
+};
+
+}  // namespace omm

--- a/src/commands/modifypointscommand.cpp
+++ b/src/commands/modifypointscommand.cpp
@@ -36,7 +36,11 @@ void ModifyPointsCommand::exchange()
       swap(*ptr, point);
     }
   }
-  for (auto& [path, _] : m_data) {
+  for (auto& [path, points_map] : m_data) {
+    const std::set<Point*> points = ::transform<Point*, std::set>(points_map, [](const auto& value) {
+      return value.first;
+    });
+    path->update_point(points);
     path->update();
   }
 }

--- a/src/disjointset.h
+++ b/src/disjointset.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <deque>
+#include <set>
+#include "common.h"
+
+namespace omm
+{
+
+/**
+ * @brief The DisjointSetForest class implements the disjoint set data structure.
+ *  It does not follow the standard implementation because we typically want to lookup all
+ *  members of a set.
+ *  The classical find method only checks whether two items belong to the same set.
+ */
+template<typename T> class DisjointSetForest
+{
+private:
+  void join(const std::set<T>& items_to_join, std::set<T>& join_target)
+  {
+    for (auto it = m_forest.begin(); it != m_forest.end(); ++it) {
+      if (!sets_disjoint(items_to_join, *it) && &*it != &join_target) {
+        join_target.insert(it->begin(), it->end());
+        it->clear();
+      }
+    }
+    std::erase_if(m_forest, [](const auto& set) { return set.empty(); });
+  }
+
+public:
+  static bool sets_disjoint(const std::set<T>& a, const std::set<T>& b)
+  {
+    return a.end() == std::find_first_of(a.begin(), a.end(), b.begin(), b.end());
+  }
+
+  /**
+   * @brief insert insert set into the forest.
+   *  If any item of set is already known, the sets are joined accordingly.
+   *  Examples:
+   *  - insert {A, B} into ()                  -> ({A, B})
+   *  - insert {C, D} into ({A, B})            -> ({A, B}, {C, D})
+   *  - insert {B, E} into ({A, B}, {C, D})    -> ({A, B, E}, {C, D})
+   *  - insert {A, C} into ({A, B}, {C, D, E}) -> ({A, B, C, D, E})
+   * @return The set from the forest that includes the given set
+   */
+  std::set<T> insert(const std::set<T>& set)
+  {
+    for (auto it = m_forest.begin(); it != m_forest.end(); ++it) {
+      if (!sets_disjoint(set, *it)) {
+        it->insert(set.begin(), set.end());
+        join(set, *it);
+        return *it;
+      }
+    }
+    m_forest.push_back(set);
+    return set;
+  }
+
+  /**
+   * @brief get returns the set that contains `key` or the empty set if there is no such.
+   */
+  std::set<T> get(const T& key)
+  {
+    for (const auto& set : m_forest) {
+      if (::contains(set, key)) {
+        return set;
+      }
+    }
+    return {};
+  }
+
+  /**
+   * @brief remove removes all items in `set` from the forest.
+   */
+  void remove(const std::set<T>& set)
+  {
+    const auto overlap = [&set](const auto& other_set) { return !sets_disjoint(other_set, set); };
+    const auto it = std::remove_if(m_forest.begin(), m_forest.end(), overlap);
+    m_forest.erase(it, m_forest.end());
+  }
+
+private:
+  std::deque<std::set<T>> m_forest;
+};
+
+}  // namespace omm

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -120,6 +120,8 @@ std::vector<QString> MainWindow::path_menu_entries()
       "path/subdivide",
       "path/select all",
       "path/deselect all",
+      "path/join points",
+      "path/disjoin points",
       "path/invert selection",
       "path/select connected points",
       "path/fill selection",

--- a/src/mainwindow/pathactions.cpp
+++ b/src/mainwindow/pathactions.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow/pathactions.h"
 #include "commands/addcommand.h"
+#include "commands/joinpointscommand.h"
 #include "commands/modifypointscommand.h"
 #include "commands/movecommand.h"
 #include "commands/objectselectioncommand.h"
@@ -26,6 +27,20 @@
 namespace
 {
 using namespace omm;
+
+auto path_selection(Application& app)
+{
+  std::map<Path*, std::set<Point*>> points;
+  for (auto* path : app.scene->item_selection<Path>()) {
+    auto& set = points[path];
+    for (auto* p : path->points()) {
+      if (p->is_selected()) {
+        set.insert(p);
+      }
+    }
+  }
+  return points;
+}
 
 template<typename F> void foreach_segment(Application& app, F&& f)
 {
@@ -342,6 +357,16 @@ void shrink_selection(Application& app)
   Q_EMIT app.mail_box().scene_appearance_changed();
 }
 
+void join_points(Application& app)
+{
+  app.scene->submit<JoinPointsCommand>(path_selection(app));
+}
+
+void disjoin_points(Application& app)
+{
+  app.scene->submit<DisjoinPointsCommand>(path_selection(app));
+}
+
 const std::map<QString, std::function<void(Application& app)>> actions{
   {"make linear", modify_tangents_linear},
   {"make smooth", modify_tangents_smooth},
@@ -355,6 +380,8 @@ const std::map<QString, std::function<void(Application& app)>> actions{
   {"fill selection", fill_selection},
   {"extend selection", extend_selection},
   {"shrink selection", shrink_selection},
+  {"disjoin points", disjoin_points},
+  {"join points", join_points},
 };
 
 }  // namespace

--- a/src/objects/path.cpp
+++ b/src/objects/path.cpp
@@ -184,4 +184,23 @@ std::deque<Point*> Path::selected_points() const
   return ::filter_if(points(), std::mem_fn(&Point::is_selected));
 }
 
+std::set<Point*> Path::join_points(const std::set<Point*>& points)
+{
+  return m_joined_points.insert(points);
+}
+
+void Path::disjoin_points(Point* point)
+{
+  m_joined_points.remove({point});
+}
+
+void Path::update_point(const std::set<Point*>& points)
+{
+  for (Point* p : points) {
+    for (Point* q : m_joined_points.get(p)) {
+      q->set_position(p->position());
+    }
+  }
+}
+
 }  // namespace omm

--- a/src/objects/path.h
+++ b/src/objects/path.h
@@ -2,6 +2,7 @@
 
 #include "cachedgetter.h"
 #include "objects/object.h"
+#include "disjointset.h"
 #include <deque>
 #include <list>
 #include <type_traits>
@@ -47,9 +48,15 @@ public:
   std::unique_ptr<Segment> remove_segment(const Segment& segment);
   std::deque<Point*> points() const;
   std::deque<Point*> selected_points() const;
+  std::set<Point*> join_points(const std::set<Point*>& points);
+  void disjoin_points(Point* point);
+  void update_point(const std::set<Point*>& points);
 
 private:
   std::deque<std::unique_ptr<Segment>> m_segments;
+  DisjointSetForest<Point*> m_joined_points;
+  friend class JoinPointsCommand;
+  friend class DisjoinPointsCommand;
 };
 
 }  // namespace omm

--- a/test/unit/common.cpp
+++ b/test/unit/common.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "logging.h"
+#include "disjointset.h"
 #include "gtest/gtest.h"
 #include <QDebug>
 #include <map>
@@ -309,4 +310,43 @@ TEST(common, coherent_ranges)
   EXPECT_EQ(prime_power_ranges[0].size, 4);
   EXPECT_EQ(prime_power_ranges[1].start, 7);
   EXPECT_EQ(prime_power_ranges[1].size, 2);
+}
+
+TEST(common, disjoint_set_forest)
+{
+  EXPECT_TRUE(omm::DisjointSetForest<int>::sets_disjoint({1, 2, 3}, {4, 5, 6}));
+  EXPECT_FALSE(omm::DisjointSetForest<int>::sets_disjoint({1, 2, 3}, {3, 5, 6}));
+  EXPECT_TRUE(omm::DisjointSetForest<int>::sets_disjoint({}, {3, 5, 6}));
+  EXPECT_TRUE(omm::DisjointSetForest<int>::sets_disjoint({3, 5, 6}, {}));
+
+  omm::DisjointSetForest<int> cluster;
+  EXPECT_EQ(cluster.get(42), std::set<int>{});
+  cluster.insert({1, 2 ,3});
+  EXPECT_EQ(cluster.get(1), std::set({1, 2, 3}));
+  EXPECT_EQ(cluster.get(2), std::set({1, 2, 3}));
+  EXPECT_EQ(cluster.get(0), std::set<int>{});
+
+  cluster.insert({4, 5});
+  EXPECT_EQ(cluster.get(1), std::set({1, 2, 3}));
+  EXPECT_EQ(cluster.get(0), std::set<int>{});
+  EXPECT_EQ(cluster.get(4), std::set({4, 5}));
+
+  cluster.remove({4});
+  EXPECT_EQ(cluster.get(1), std::set({1, 2, 3}));
+  EXPECT_EQ(cluster.get(4), std::set<int>{});
+  EXPECT_EQ(cluster.get(5), std::set<int>{});
+
+  cluster.insert({4, 5});
+  cluster.insert({1, 6, 7});
+  EXPECT_EQ(cluster.get(1), std::set({1, 2, 3, 6, 7}));
+  EXPECT_EQ(cluster.get(6), std::set({1, 2, 3, 6, 7}));
+
+  cluster.insert({1, 4});
+  EXPECT_EQ(cluster.get(1), std::set({1, 2, 3, 4, 5, 6, 7}));
+  EXPECT_EQ(cluster.get(3), std::set({1, 2, 3, 4, 5, 6, 7}));
+
+  cluster.remove({4});
+  EXPECT_EQ(cluster.get(1), std::set<int>{});
+  EXPECT_EQ(cluster.get(4), std::set<int>{});
+  EXPECT_EQ(cluster.get(5), std::set<int>{});
 }


### PR DESCRIPTION
resolves #75 

- First draft
- Move the connected points to see the result
- No undo/redo yet, usability is quite limited

Appreciate early feedback and ideas, it won't be trivial to integrate this well into a workflow.
Technically, n-joints are implemented as interlocked points.
For example, brushes and selections do not work as expected.