### PR TITLE
Draw Faces of PathObject separately

### DIFF
--- a/src/commands/modifypointscommand.cpp
+++ b/src/commands/modifypointscommand.cpp
@@ -190,6 +190,7 @@ bool operator<(const AbstractPointsCommand::OwnedLocatedPath& a,
     return std::tuple{ola.m_path, ola.m_owned_path.get(), ola.m_index};
   };
 
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   return as_tuple(a) < as_tuple(b);
 }
 

--- a/src/commands/modifypointscommand.cpp
+++ b/src/commands/modifypointscommand.cpp
@@ -5,6 +5,7 @@
 #include "path/path.h"
 #include "path/pathpoint.h"
 #include "path/pathvector.h"
+#include "path/pathview.h"
 
 namespace omm
 {
@@ -116,6 +117,8 @@ void AbstractPointsCommand::remove()
   m_path_object.scene()->update_tool();
 }
 
+AbstractPointsCommand::~AbstractPointsCommand() = default;
+
 AddPointsCommand::AddPointsCommand(PathObject& path_object, std::deque<OwnedLocatedPath>&& added_points)
     : AbstractPointsCommand(static_label(), path_object, std::move(added_points))
 {
@@ -165,6 +168,8 @@ AbstractPointsCommand::OwnedLocatedPath::OwnedLocatedPath(std::unique_ptr<Path> 
 {
   assert(m_owned_path != nullptr);
 }
+
+AbstractPointsCommand::OwnedLocatedPath::~OwnedLocatedPath() = default;
 
 PathView AbstractPointsCommand::OwnedLocatedPath::insert_into(PathVector& path_vector)
 {

--- a/src/commands/modifypointscommand.h
+++ b/src/commands/modifypointscommand.h
@@ -64,7 +64,13 @@ protected:
   void remove();
 
   [[nodiscard]] Scene& scene() const;
-  virtual ~AbstractPointsCommand();
+  ~AbstractPointsCommand() override;
+
+public:
+  AbstractPointsCommand(const AbstractPointsCommand&) = delete;
+  AbstractPointsCommand(AbstractPointsCommand&&) = delete;
+  AbstractPointsCommand& operator=(const AbstractPointsCommand&) = delete;
+  AbstractPointsCommand& operator=(AbstractPointsCommand&&) = delete;
 
 private:
   PathObject& m_path_object;

--- a/src/commands/modifypointscommand.h
+++ b/src/commands/modifypointscommand.h
@@ -3,6 +3,7 @@
 #include "commands/command.h"
 #include <deque>
 #include <memory>
+#include "path/pathview.h"
 
 namespace omm
 {
@@ -37,6 +38,11 @@ public:
   public:
     explicit OwnedLocatedPath(Path* path, std::size_t index, std::deque<std::unique_ptr<PathPoint>>&& points);
     explicit OwnedLocatedPath(std::unique_ptr<Path> path);
+    ~OwnedLocatedPath();
+    OwnedLocatedPath(OwnedLocatedPath&& other) = default;
+    OwnedLocatedPath& operator=(OwnedLocatedPath&& other) = default;
+    OwnedLocatedPath(const OwnedLocatedPath& other) = delete;
+    OwnedLocatedPath& operator=(const OwnedLocatedPath& other) = delete;
     PathView insert_into(PathVector& path_vector);
     friend bool operator<(const OwnedLocatedPath& a, const OwnedLocatedPath& b);
 
@@ -58,6 +64,7 @@ protected:
   void remove();
 
   [[nodiscard]] Scene& scene() const;
+  virtual ~AbstractPointsCommand();
 
 private:
   PathObject& m_path_object;

--- a/src/disjointset.h
+++ b/src/disjointset.h
@@ -95,6 +95,12 @@ public:
 
 protected:
   std::deque<Joint> m_forest;
+  void remove_empty_sets()
+  {
+    m_forest.erase(std::remove_if(m_forest.begin(), m_forest.end(), [](const auto& set) {
+      return set.empty();
+    }), m_forest.end());
+  }
 };
 
 template<typename T> void swap(DisjointSetForest<T>& a, DisjointSetForest<T>& b) noexcept

--- a/src/objects/object.cpp
+++ b/src/objects/object.cpp
@@ -666,25 +666,26 @@ void Object::draw_object(Painter& renderer,
                          const Style& style,
                          const PainterOptions& options) const
 {
+  options.object_id = id();
   if (QPainter* painter = renderer.painter; painter != nullptr && is_active()) {
     const auto& path_vector = this->path_vector();
     const auto faces = path_vector.faces();
     const auto& outline = path_vector.outline();
     if (!faces.empty() || !outline.isEmpty()) {
-      renderer.set_style(style, *this, options);
-      auto& painter = *renderer.painter;
 
-      for (const auto& face : faces) {
-        painter.save();
-        painter.setPen(Qt::NoPen);
-        painter.drawPath(face);
-        painter.restore();
+      for (std::size_t f = 0; f < faces.size(); ++f) {
+        options.path_id = f;
+        renderer.set_style(style, *this, options);
+        painter->save();
+        painter->setPen(Qt::NoPen);
+        painter->drawPath(faces.at(f));
+        painter->restore();
       }
 
-      painter.save();
+      painter->save();
       renderer.painter->setBrush(Qt::NoBrush);
-      painter.drawPath(outline);
-      painter.restore();
+      painter->drawPath(outline);
+      painter->restore();
 
       const auto marker_color = style.property(Style::PEN_COLOR_KEY)->value<Color>();
       const auto width = style.property(Style::PEN_WIDTH_KEY)->value<double>();

--- a/src/path/CMakeLists.txt
+++ b/src/path/CMakeLists.txt
@@ -7,10 +7,12 @@ target_sources(libommpfritt PRIVATE
   graph.h
   lib2geomadapter.cpp
   lib2geomadapter.h
-  pathvector.h
-  pathvector.cpp
   pathpoint.cpp
   pathpoint.h
   path.cpp
   path.h
+  pathvector.cpp
+  pathvector.h
+  pathview.cpp
+  pathview.h
 )

--- a/src/path/edge.h
+++ b/src/path/edge.h
@@ -13,7 +13,6 @@ class Edge
 {
 public:
   Edge() = default;
-  [[nodiscard]] std::vector<PathPoint*> points() const;
   [[nodiscard]] QString label() const;
 
   [[nodiscard]] Point start_geometry() const;

--- a/src/path/face.cpp
+++ b/src/path/face.cpp
@@ -111,4 +111,31 @@ QString Face::to_string() const
   return static_cast<QStringList>(edges).join(", ");
 }
 
+bool operator==(const Face& a, const Face& b)
+{
+  const auto n = a.edges().size();
+  if (n != b.edges().size()) {
+    return false;
+  }
+
+  const auto face_equal = [n](const Face& a, const Face& b, std::size_t offset, bool reverse) {
+    for (std::size_t i = 0; i < n; ++i) {
+      const auto j = (i + offset) % n;
+      const auto a_edge = a.edges().at(i);
+      const auto b_edge = b.edges().at(reverse ? n - j - 1 : j);
+      if (a_edge.a != b_edge.a || a_edge.b != b_edge.b) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  for (std::size_t i = 0; i < n; ++i) {
+    if (face_equal(a, b, i, true) || face_equal(a, b, i, false)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace omm

--- a/src/path/face.h
+++ b/src/path/face.h
@@ -26,7 +26,7 @@ public:
   [[nodiscard]] double compute_aabb_area() const;
   [[nodiscard]] QString to_string() const;
 
-  friend bool operator==(const Face& f1, const Face& f2);
+  friend bool operator==(const Face& a, const Face& b);
 
 private:
   std::deque<Edge> m_edges;

--- a/src/path/face.h
+++ b/src/path/face.h
@@ -25,6 +25,9 @@ public:
   [[nodiscard]] const std::deque<Edge>& edges() const;
   [[nodiscard]] double compute_aabb_area() const;
   [[nodiscard]] QString to_string() const;
+
+  friend bool operator==(const Face& f1, const Face& f2);
+
 private:
   std::deque<Edge> m_edges;
 };

--- a/src/path/face.h
+++ b/src/path/face.h
@@ -8,6 +8,7 @@ namespace omm
 {
 
 class Point;
+class PathPoint;
 class Edge;
 
 class Face
@@ -21,7 +22,24 @@ public:
   Face& operator=(Face&&) = default;
 
   bool add_edge(const Edge& edge);
+
+  /**
+   * @brief points returns the geometry of each point around the face with proper tangents.
+   * @note a face with `n` edges yields `n+1` points, because start and end point are listed
+   *  separately.
+   *  that's quite convenient for drawing paths.
+   * @see path_points
+   */
   [[nodiscard]] std::list<Point> points() const;
+
+  /**
+   * @brief path_points returns the points around the face.
+   * @note a face with `n` edges yields `n` points, because start and end point are not listed
+   *  separately.
+   *  That's quite convenient for checking face equality.
+   * @see points
+   */
+  [[nodiscard]] std::deque<PathPoint*> path_points() const;
   [[nodiscard]] const std::deque<Edge>& edges() const;
   [[nodiscard]] double compute_aabb_area() const;
   [[nodiscard]] QString to_string() const;

--- a/src/path/graph.cpp
+++ b/src/path/graph.cpp
@@ -135,7 +135,9 @@ std::vector<Face> Graph::compute_faces() const
   faces.erase(std::next(faces.begin(), largest_face_i));
 
   // NOLINTNEXTLINE(modernize-return-braced-init-list)
-  return std::vector(faces.begin(), faces.end());
+  std::vector vfaces(faces.begin(), faces.end());
+  vfaces.erase(std::unique(vfaces.begin(), vfaces.end()), vfaces.end());
+  return vfaces;
 }
 
 void Graph::Impl::add_vertex(PathPoint* path_point)

--- a/src/path/graph.cpp
+++ b/src/path/graph.cpp
@@ -6,7 +6,8 @@
 #include "path/path.h"
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/planar_face_traversal.hpp>
-#include <boost/graph/boyer_myrvold_planar_test.hpp>
+#include <boost/graph/biconnected_components.hpp>
+#include <boost/property_map/property_map.hpp>
 
 namespace
 {
@@ -87,7 +88,6 @@ Graph::Graph(const PathVector& path_vector)
       last_path_point = point;
     }
   }
-  identify_edges(*m_impl);
 }
 
 std::vector<Face> Graph::compute_faces() const
@@ -121,6 +121,7 @@ std::vector<Face> Graph::compute_faces() const
     const Impl& m_impl;
   };
 
+  identify_edges(*m_impl);
   const auto embedding = m_impl->compute_embedding();
   Visitor visitor{*m_impl, faces};
   boost::planar_face_traversal(*m_impl, &embedding[0], visitor);
@@ -261,6 +262,22 @@ QString Graph::to_dot() const
   }
   dot += "}";
   return dot;\
+}
+
+void Graph::remove_articulation_edges() const
+{
+//  auto components = get(boost::edge_index, *m_impl);
+//  const auto n = boost::biconnected_components(*m_impl, components);
+//  LINFO << "Found " << n << " biconnected components.";
+  std::set<std::size_t> art_points;
+  boost::articulation_points(*m_impl, std::inserter(art_points, art_points.end()));
+  const auto edge_between_articulation_points = [&art_points, this](const Impl::edge_descriptor& e) {
+    const auto o = [&art_points, this](const Impl::vertex_descriptor& v) {
+      return degree(v, *m_impl) <= 1 || art_points.contains(v);
+    };
+    return o(e.m_source) && o(e.m_target);
+  };
+  boost::remove_edge_if(edge_between_articulation_points, *m_impl);
 }
 
 }  // namespace omm

--- a/src/path/graph.h
+++ b/src/path/graph.h
@@ -27,6 +27,14 @@ public:
   [[nodiscard]] std::vector<Face> compute_faces() const;
   [[nodiscard]] QString to_dot() const;
 
+  /**
+   * @brief remove_articulation_edges an edge is articulated if it connects two articulated points,
+   *  two points of degree one or less or an articulated point with a point of degree one or less.
+   *  Removing articulated edges from a graph increase the number of components by one.
+   *  Articulated edges can never be part of a face.
+   */
+  void remove_articulation_edges() const;
+
 private:
   std::unique_ptr<Impl> m_impl;
 };

--- a/src/path/path.cpp
+++ b/src/path/path.cpp
@@ -228,25 +228,4 @@ void Path::deserialize(AbstractDeserializer& deserializer, const Pointer& root)
   }
 }
 
-PathView::PathView(Path& path, std::size_t index, std::size_t size)
-  : path(&path), index(index), size(size)
-{
-}
-
-bool operator<(const PathView& a, const PathView& b)
-{
-  static constexpr auto as_tuple = [](const PathView& a) {
-    return std::tuple{a.path, a.index};
-  };
-
-  // NOLINTNEXTLINE(modernize-use-nullptr)
-  return as_tuple(a) < as_tuple(b);
-}
-
-std::ostream& operator<<(std::ostream& ostream, const PathView& path_view)
-{
-  ostream << "Path[" << path_view.path << " " << path_view.index << " " << path_view.size << "]";
-  return ostream;
-}
-
 }  // namespace omm

--- a/src/path/path.h
+++ b/src/path/path.h
@@ -16,17 +16,6 @@ class PathPoint;
 // NOLINTNEXTLINE(bugprone-forward-declaration-namespace)
 class Path;
 
-struct PathView
-{
-public:
-  explicit PathView(Path& path, std::size_t index, std::size_t size);
-  friend bool operator<(const PathView& a, const PathView& b);
-  friend std::ostream& operator<<(std::ostream& ostream, const PathView& path_view);
-  Path* path;
-  std::size_t index;
-  std::size_t size;
-};
-
 // NOLINTNEXTLINE(bugprone-forward-declaration-namespace)
 class PathVector;
 

--- a/src/path/pathpoint.cpp
+++ b/src/path/pathpoint.cpp
@@ -53,6 +53,22 @@ Point PathPoint::compute_joined_point_geometry(PathPoint& joined) const
   return geometry;
 }
 
+bool PathPoint::is_dangling() const
+{
+  if (path_vector() == nullptr || !path().contains(*this)) {
+    return true;
+  }
+  if (!::contains(path_vector()->paths(), &path())) {
+    return false;
+  }
+  const auto* const path_object = path_vector()->path_object();
+  if (path_object == nullptr) {
+    return false;
+  }
+  const auto* const scene = path_object->scene();
+  return scene == nullptr || !scene->contains(path_object);
+}
+
 QString PathPoint::debug_id() const
 {
   auto joins = util::transform<const PathPoint*, ::transparent_set>(joined_points());

--- a/src/path/pathpoint.h
+++ b/src/path/pathpoint.h
@@ -42,6 +42,7 @@ public:
   void disjoin();
   [[nodiscard]] PathVector* path_vector() const;
   [[nodiscard]] Point compute_joined_point_geometry(PathPoint& joined) const;
+  [[nodiscard]] bool is_dangling() const;
 
   /**
    * @brief debug_id returns an string to identify the point uniquely at this point in time

--- a/src/path/pathvector.cpp
+++ b/src/path/pathvector.cpp
@@ -170,6 +170,23 @@ std::vector<QPainterPath> PathVector::faces() const
   for (const auto& face : faces) {
     qpps.emplace_back(Path::to_painter_path(face.points()));
   }
+
+  for (bool path_changed = true; path_changed;)
+  {
+    path_changed = false;
+    for (auto& q1 : qpps) {
+      for (auto& q2 : qpps) {
+        if (&q1 == &q2) {
+          continue;
+        }
+        if (q1.contains(q2)) {
+          path_changed = true;
+          q1 -= q2;
+        }
+      }
+    }
+  }
+
   return qpps;
 }
 

--- a/src/path/pathvector.cpp
+++ b/src/path/pathvector.cpp
@@ -163,7 +163,8 @@ QPainterPath PathVector::outline() const
 std::vector<QPainterPath> PathVector::faces() const
 {
   Graph graph{*this};
-  auto faces = graph.compute_faces();
+  graph.remove_articulation_edges();
+  const auto faces = graph.compute_faces();
   std::vector<QPainterPath> qpps;
   qpps.reserve(faces.size());
   for (const auto& face : faces) {

--- a/src/path/pathview.cpp
+++ b/src/path/pathview.cpp
@@ -1,0 +1,42 @@
+#include "path/pathview.h"
+#include <tuple>
+#include <ostream>
+#include "path/path.h"
+
+namespace omm
+{
+
+PathView::PathView(Path& path, std::size_t index, std::size_t size)
+  : path(&path), index(index), size(size)
+{
+}
+
+PathPoint& PathView::at(std::size_t i) const
+{
+  return path->at(index + i);
+}
+
+std::deque<PathPoint*> PathView::points() const
+{
+  auto points = path->points();
+  points.erase(points.begin(), std::next(points.begin(), index));
+  points.erase(std::next(points.begin(), size), points.end());
+  return points;
+}
+
+bool operator<(const PathView& a, const PathView& b)
+{
+  static constexpr auto as_tuple = [](const PathView& a) {
+    return std::tuple{a.path, a.index};
+  };
+  // NOLINTNEXTLINE(modernize-use-nullptr)
+  return as_tuple(a) < as_tuple(b);
+}
+
+std::ostream& operator<<(std::ostream& ostream, const PathView& path_view)
+{
+  ostream << "Path[" << path_view.path << " " << path_view.index << " " << path_view.size << "]";
+  return ostream;
+}
+
+}  // namespace omm

--- a/src/path/pathview.cpp
+++ b/src/path/pathview.cpp
@@ -11,11 +11,6 @@ PathView::PathView(Path& path, std::size_t index, std::size_t size)
 {
 }
 
-PathPoint& PathView::at(std::size_t i) const
-{
-  return path->at(index + i);
-}
-
 std::deque<PathPoint*> PathView::points() const
 {
   auto points = path->points();

--- a/src/path/pathview.h
+++ b/src/path/pathview.h
@@ -16,7 +16,6 @@ public:
   explicit PathView(Path& path, std::size_t index, std::size_t size);
   friend bool operator<(const PathView& a, const PathView& b);
   friend std::ostream& operator<<(std::ostream& ostream, const PathView& path_view);
-  [[nodiscard]] PathPoint& at(std::size_t i) const;
   [[nodiscard]] std::deque<PathPoint*> points() const;
   Path* path;
   std::size_t index;

--- a/src/path/pathview.h
+++ b/src/path/pathview.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+#include <iosfwd>
+#include <deque>
+
+namespace omm
+{
+
+class Path;
+class PathPoint;
+
+struct PathView
+{
+public:
+  explicit PathView(Path& path, std::size_t index, std::size_t size);
+  friend bool operator<(const PathView& a, const PathView& b);
+  friend std::ostream& operator<<(std::ostream& ostream, const PathView& path_view);
+  [[nodiscard]] PathPoint& at(std::size_t i) const;
+  [[nodiscard]] std::deque<PathPoint*> points() const;
+  Path* path;
+  std::size_t index;
+  std::size_t size;
+};
+
+}  // namepsace

--- a/src/renderers/offscreenrenderer.cpp
+++ b/src/renderers/offscreenrenderer.cpp
@@ -42,6 +42,16 @@ const std::vector<OffscreenRenderer::ShaderInput> OffscreenRenderer::fragment_sh
         QT_TRANSLATE_NOOP("OffscreenRenderer", "view_pos"),
         ShaderInput::Kind::Varying,
     },
+    {
+        Type::Integer,
+        QT_TRANSLATE_NOOP("OffscreenRenderer", "object_id"),
+        ShaderInput::Kind::Uniform,
+    },
+    {
+        Type::Integer,
+        QT_TRANSLATE_NOOP("OffscreenRenderer", "path_id"),
+        ShaderInput::Kind::Uniform,
+    },
 };
 
 QString OffscreenRenderer::ShaderInput::tr_name() const
@@ -70,6 +80,8 @@ uniform mat3 view_transform;
 uniform vec2 view_size;
 uniform vec2 roi_tl;
 uniform vec2 roi_br;
+uniform int object_id;
+uniform int path_id;
 
 vec2 unc(vec2 centered) {
   return (centered + vec2(1.0, 1.0)) / 2.0;
@@ -311,6 +323,8 @@ Texture OffscreenRenderer::render(const Object& object,
   ::set_uniform(*this, "view_size", Vec2f(options.device.width(), options.device.height()));
   ::set_uniform(*this, "roi_tl", Vec2f(roi.topLeft()));
   ::set_uniform(*this, "roi_br", Vec2f(roi.bottomRight()));
+  ::set_uniform(*this, "object_id", options.object_id);
+  ::set_uniform(*this, "path_id", options.path_id);
 
   m_vertices.bind();
 

--- a/src/renderers/painter.cpp
+++ b/src/renderers/painter.cpp
@@ -105,7 +105,9 @@ void Painter::toast(const Vec2f& pos, const QString& text) const
 }
 
 QBrush
-Painter::make_brush(const Style& style, const Object& object, const PainterOptions& options)
+Painter::make_brush(const Style& style,
+                    const Object& object,
+                    const PainterOptions& options)
 {
   if (style.property(omm::Style::BRUSH_IS_ACTIVE_KEY)->value<bool>()) {
     if (style.property("gl-brush")->value<bool>()) {

--- a/src/renderers/painter.h
+++ b/src/renderers/painter.h
@@ -43,7 +43,9 @@ public:
 
   void toast(const Vec2f& pos, const QString& text) const;
 
-  static QBrush make_brush(const Style& style, const Object& object, const PainterOptions& options);
+  static QBrush make_brush(const Style& style,
+                           const Object& object,
+                           const PainterOptions& options);
   static QPen make_pen(const Style& style, const Object& object);
 
   static QBrush make_simple_brush(const Style& style);

--- a/src/renderers/painteroptions.h
+++ b/src/renderers/painteroptions.h
@@ -18,6 +18,8 @@ struct PainterOptions
   const Style* default_style = nullptr;
   const bool device_is_viewport;
   const QPaintDevice& device;
+  mutable std::size_t object_id;
+  mutable std::size_t path_id = 0;
 };
 
 }  // namespace omm

--- a/src/scene/disjointpathpointsetforest.h
+++ b/src/scene/disjointpathpointsetforest.h
@@ -16,6 +16,7 @@ public:
   void deserialize(AbstractDeserializer& deserializer, const Pointer& root) override;
   void serialize(AbstractSerializer& serializer, const Pointer& root) const override;
   void remove_dangling_points();
+  void remove_if(const std::function<bool(const PathPoint* point)>& predicate);
   void replace(const std::map<PathPoint*, PathPoint*>& dict);
 
 private:

--- a/src/tools/pathtool.cpp
+++ b/src/tools/pathtool.cpp
@@ -119,7 +119,7 @@ public:
 
   void ensure_active_path(Scene& scene, PathTool::Current& current)
   {
-    if (current.path == nullptr) {
+    if (current.path_object == nullptr) {
       start_macro();
       static constexpr auto insert_mode = Application::InsertionMode::Default;
       auto& path_object = Application::instance().insert_object(PathObject::TYPE, insert_mode);

--- a/test/unit/pathtest.cpp
+++ b/test/unit/pathtest.cpp
@@ -4,15 +4,45 @@
 #include "path/graph.h"
 #include "path/edge.h"
 #include "path/face.h"
+#include "path/pathpoint.h"
 #include "scene/disjointpathpointsetforest.h"
 
-using namespace omm;
-
-auto make_face(const PathVector& pv, const std::vector<std::pair<int, int>>& indices)
+namespace
 {
-  Face face;
+
+class EdgeLoop
+{
+public:
+  EdgeLoop(const std::size_t n)
+    : m_path(m_path_vector.add_path(std::make_unique<omm::Path>()))
+    , m_edges(create_edge_loop(n))
+  {
+  }
+
+  const auto& edges() const { return m_edges; }
+
+private:
+  omm::PathVector m_path_vector;
+  omm::Path& m_path;
+  const std::deque<omm::Edge> m_edges;
+
+  std::deque<omm::Edge> create_edge_loop(const std::size_t n) const
+  {
+    assert(n >= 2);
+    std::deque<omm::Edge> edges(n);
+    for (std::size_t i = 0; i < n; ++i) {
+      edges.at(i).a = &m_path.add_point({});
+      edges.at((i + 1) % n).b = edges.at(i).a;
+    }
+    return edges;
+  }
+};
+
+auto make_face(const omm::PathVector& pv, const std::vector<std::pair<int, int>>& indices)
+{
+  omm::Face face;
   for (const auto& [ai, bi] : indices) {
-    Edge edge;
+    omm::Edge edge;
     edge.a = &pv.point_at_index(ai);
     edge.b = &pv.point_at_index(bi);
     face.add_edge(edge);
@@ -20,10 +50,88 @@ auto make_face(const PathVector& pv, const std::vector<std::pair<int, int>>& ind
   return face;
 }
 
+omm::Face create_face(const std::deque<omm::Edge>& edges, const int offset, const bool reverse)
+{
+  std::deque<omm::Edge> es;
+  std::rotate_copy(edges.begin(), edges.begin() + offset, edges.end(), std::back_insert_iterator(es));
+  if (reverse) {
+    std::reverse(es.begin(), es.end());
+  }
+  omm::Face face;
+  for (const auto& edge : es) {
+    static constexpr auto r = [](const omm::Edge& e) {
+      omm::Edge r;
+      r.a = e.b;
+      r.b = e.a;
+      return r;
+    };
+    face.add_edge(reverse ? r(edge) : edge);
+  }
+  return face;
+}
+
+}  // namespace
+
+TEST(Path, FaceAddEdge)
+{
+  const EdgeLoop loop(4);
+
+  static constexpr auto expect_true_perms = {
+    std::array{0, 1, 2, 3},
+    std::array{1, 2, 3, 0},
+    std::array{3, 2, 1, 0},
+    std::array{2, 1, 0, 3},
+  };
+
+  for (const auto permutation : expect_true_perms) {
+    omm::Face face;
+    for (const std::size_t i : permutation) {
+      EXPECT_TRUE(face.add_edge(loop.edges().at(i)));
+    }
+  }
+
+  // It adding the third edge is expected to fail because there's no way to orient it such that it
+  // has a common point with the previous edge.
+  // Hence, adding a fourth edge is not required.
+  static constexpr auto expect_false_perms = {
+    std::array{0, 1, 3},
+    std::array{2, 1, 3},
+    std::array{1, 2, 0},
+    std::array{1, 0, 2},
+  };
+
+  for (const auto permutation : expect_false_perms) {
+    omm::Face face;
+    for (std::size_t k = 0; k < permutation.size() - 1; ++k) {
+      EXPECT_TRUE(face.add_edge(loop.edges().at(permutation.at(k))));
+    }
+    EXPECT_FALSE(face.add_edge(loop.edges().at(permutation.back())));
+  }
+}
+
+TEST(Path, FaceEquality)
+{
+  EdgeLoop loop(4);
+  for (std::size_t i = 0; i < loop.edges().size(); ++i) {
+    EXPECT_EQ(create_face(loop.edges(), 0, false), create_face(loop.edges(), i, false));
+    EXPECT_EQ(create_face(loop.edges(), 0, true), create_face(loop.edges(), i, false));
+    EXPECT_EQ(create_face(loop.edges(), i, true), create_face(loop.edges(), 0, true));
+  }
+
+  auto scrambled_edges = loop.edges();
+  std::swap(scrambled_edges.at(0), scrambled_edges.at(1));
+  for (std::size_t i = 0; i < loop.edges().size(); ++i) {
+    EXPECT_NE(create_face(scrambled_edges, 0, false), create_face(loop.edges(), i, false));
+    EXPECT_NE(create_face(scrambled_edges, 0, true), create_face(loop.edges(), i, false));
+    EXPECT_NE(create_face(scrambled_edges, i, true), create_face(loop.edges(), 0, true));
+  }
+
+}
+
 TEST(Path, face_detection)
 {
 
-  PathVector path_vector;
+  omm::PathVector path_vector;
 
   // define following path vector:
   //
@@ -31,6 +139,10 @@ TEST(Path, face_detection)
   //    |         |        |
   //    |         |        |
   //  (0,4) --- (1,5) --- (6)
+
+  using omm::Path;
+  using omm::Point;
+  using omm::Graph;
 
   const auto as = path_vector.add_path(std::make_unique<Path>(std::deque<Point>{
                                            Point{{0.0, 0.0}},  // 0
@@ -52,11 +164,8 @@ TEST(Path, face_detection)
   path_vector.joined_points().insert({as[2], bs[3]});
 
   const Graph graph{path_vector};
-  const auto dot = graph.to_dot();
-  LINFO << dot;
-
   const auto faces = graph.compute_faces();
   ASSERT_EQ(faces.size(), 2);
-  ASSERT_TRUE(faces[0] == make_face(path_vector, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}));
-  ASSERT_TRUE(faces[1] == make_face(path_vector, {{5, 6}, {6, 7}, {7, 8}, {1, 2}}));
+  ASSERT_EQ(faces[0], make_face(path_vector, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}));
+  ASSERT_EQ(faces[1], make_face(path_vector, {{5, 6}, {6, 7}, {7, 8}, {1, 2}}));
 }

--- a/test/unit/pathtest.cpp
+++ b/test/unit/pathtest.cpp
@@ -20,42 +20,6 @@ auto make_face(const PathVector& pv, const std::vector<std::pair<int, int>>& ind
   return face;
 }
 
-// Considering the loop without joints (A) --e1-- (B) --e2-- (A), e1 and e2 will be considered equal.
-// However, this case does not occur during testing.
-bool edge_equal(const Edge& a, const Edge& b)
-{
-  return std::set{a.a, a.b} == std::set{b.a, b.b};
-}
-
-bool operator==(const Face& a, const Face& b)
-{
-  const auto& a_edges = a.edges();
-  const auto& b_edges = b.edges();
-  if (a_edges.size() != b_edges.size()) {
-    return false;
-  }
-
-  const auto n = a_edges.size();
-  const auto rotation_match = [n, &a_edges, &b_edges](const int offset, bool reverse) {
-    for (std::size_t j = 0; j < n; ++j) {
-      const auto ai = reverse ? n - j - 1 : j;
-      const auto bi = (j + offset) % n;
-      if (!edge_equal(a_edges[ai], b_edges[bi])) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  for (std::size_t i = 0; i < n; ++i) {
-    if (rotation_match(i, false) || rotation_match(i, true)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 TEST(Path, face_detection)
 {
 

--- a/test/unit/pathtest.cpp
+++ b/test/unit/pathtest.cpp
@@ -13,7 +13,7 @@ namespace
 class EdgeLoop
 {
 public:
-  EdgeLoop(const std::size_t n)
+  explicit EdgeLoop(const std::size_t n)
     : m_path(m_path_vector.add_path(std::make_unique<omm::Path>()))
     , m_edges(create_edge_loop(n))
   {


### PR DESCRIPTION
Draw a circular path and another circular path completely within the first one (both paths are not connected but belong to the same `PathObject`).
- Old behavior: There are two faces, the outer and the inner circle. If you assign a semi-transparent brush, you will notice that the inner of the inner circle is part of both faces (it's less transparent).
- New behavior: The outer circle has a hole, the hole is drawn just once (because the inner circle covers it). Semi-transparent styles are rendered correctly.

This is important now for semi-transparent styles and will be even more important in the future when the filling can be enabled face-wise.

See #226 